### PR TITLE
feat: (sub)geographics and enum filters for funder API

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -38,6 +38,7 @@ gem "aws-sdk-s3"
 gem "rgeo"
 gem "rgeo-geojson"
 gem "standard"
+gem "closure_tree"
 
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -145,6 +145,9 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cliver (0.3.2)
+    closure_tree (7.4.0)
+      activerecord (>= 4.2.10)
+      with_advisory_lock (>= 4.0.0)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
     crack (0.4.5)
@@ -401,6 +404,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_advisory_lock (4.6.0)
+      activerecord (>= 4.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.0)
@@ -428,6 +433,7 @@ DEPENDENCIES
   capistrano-rvm (~> 0.1.2)
   capistrano-yarn (~> 2.0.2)
   capybara (>= 3.26)
+  closure_tree
   cuprite
   debug
   dotenv-rails

--- a/backend/app/controllers/api/v1/funders_controller.rb
+++ b/backend/app/controllers/api/v1/funders_controller.rb
@@ -6,13 +6,13 @@ module API
       ENUM_FILTERS = %i[areas demographics funder_types capital_types funder_legal_status]
 
       def index
-        @funders = @funders.includes :primary_office_state, :primary_office_country, :subgeographics, :subgeographic_ancestors
         @funders = @funders.for_subgeographics filter_params[:subgeographic_ids] if filter_params[:subgeographic_ids].present?
         @funders = @funders.for_geographics filter_params[:geographics] if filter_params[:geographics].present?
         @funders = API::EnumFilter.new(@funders, filter_params.to_h.slice(*ENUM_FILTERS)).call
-        @funders = @funders.order :name
+        @funders = Funder.where(id: @funders.pluck(:id)).order(:name)
+          .includes :primary_office_state, :primary_office_country, :subgeographics, :subgeographic_ancestors
         render json: FunderSerializer.new(
-          @funders.distinct,
+          @funders,
           include: included_relationships,
           fields: sparse_fieldset,
           params: {current_user: current_user, current_ability: current_ability}

--- a/backend/app/models/funder.rb
+++ b/backend/app/models/funder.rb
@@ -4,6 +4,7 @@ class Funder < ApplicationRecord
 
   has_many :funder_subgeographics, dependent: :destroy
   has_many :subgeographics, through: :funder_subgeographics
+  has_many :subgeographic_ancestors, through: :subgeographics, source: :subgeographic_ancestors
 
   has_one_attached :logo
 
@@ -32,4 +33,7 @@ class Funder < ApplicationRecord
     :primary_contact_location,
     :date_joined_fora,
     :number_staff_employees
+
+  scope :for_subgeographics, ->(ids) { joins(:subgeographic_ancestors).where(subgeographics: {id: ids}) }
+  scope :for_geographics, ->(geographics) { joins(:subgeographic_ancestors).where(subgeographics: {geographic: geographics}) }
 end

--- a/backend/app/models/subgeographic.rb
+++ b/backend/app/models/subgeographic.rb
@@ -1,8 +1,15 @@
 class Subgeographic < ApplicationRecord
+  has_closure_tree
+
   belongs_to :parent, class_name: "Subgeographic", optional: true
   belongs_to :subgeographic_geometry, optional: true
 
   has_many :subgeographics, foreign_key: "parent_id", dependent: :destroy
+  has_many :hierarchy_ancestors, class_name: "SubgeographicHierarchy", foreign_key: "descendant_id", dependent: :destroy
+  has_many :subgeographic_ancestors, class_name: "Subgeographic", through: :hierarchy_ancestors, source: :ancestor
+  has_many :hierarchy_descendants, class_name: "SubgeographicHierarchy", foreign_key: "ancestor_id", dependent: :destroy
+  has_many :subgeographic_descendants, class_name: "Subgeographic", through: :hierarchy_descendants, source: :descendant
+
   has_many :funder_primary_office_states, class_name: "Funder", foreign_key: "primary_office_state_id", dependent: :destroy
   has_many :funder_primary_office_countries, class_name: "Funder", foreign_key: "primary_office_country_id", dependent: :destroy
   has_many :funder_subgeographics, dependent: :destroy

--- a/backend/app/serializers/api/v1/funder_serializer.rb
+++ b/backend/app/serializers/api/v1/funder_serializer.rb
@@ -38,6 +38,7 @@ module API
       belongs_to_restricted :primary_office_country, serializer: :subgeographic
 
       has_many_restricted :subgeographics
+      has_many_restricted :subgeographic_ancestors, serializer: :subgeographic
 
       attribute :contact_email do |object, _params|
         next object.secondary_email_which_can_be_shared unless object.show_primary_email?

--- a/backend/app/services/api/enum_filter.rb
+++ b/backend/app/services/api/enum_filter.rb
@@ -1,0 +1,33 @@
+module API
+  class EnumFilter
+    attr_accessor :query, :filters
+
+    def initialize(query, filters)
+      @query = query
+      @filters = filters
+    end
+
+    def call
+      query.merge build_enum_query
+    end
+
+    private
+
+    def build_enum_query
+      pluralize_keys_in(filters).slice(*column_names).inject(query.klass.all) do |enum_query, (filter_key, filter_value)|
+        enum_query.where ActiveRecord::Base.sanitize_sql(["ARRAY[#{filter_key}]::text[] && ARRAY[?]::text[]", Array.wrap(filter_value)])
+      end
+    end
+
+    def pluralize_keys_in(hash)
+      hash.each_with_object({}) do |(key, value), res|
+        res[key.to_s] = value
+        res[key.to_s.pluralize] = value
+      end
+    end
+
+    def column_names
+      @column_names ||= query.klass.column_names
+    end
+  end
+end

--- a/backend/db/migrate/20221006111547_create_subgeographic_hierarchies.rb
+++ b/backend/db/migrate/20221006111547_create_subgeographic_hierarchies.rb
@@ -1,0 +1,14 @@
+class CreateSubgeographicHierarchies < ActiveRecord::Migration[7.0]
+  def change
+    create_table :subgeographic_hierarchies, id: false do |t|
+      t.references :ancestor, null: false, foreign_key: {on_delete: :cascade, to_table: :subgeographics}, type: :uuid
+      t.references :descendant, null: false, foreign_key: {on_delete: :cascade, to_table: :subgeographics}, type: :uuid
+      t.integer :generations, null: false
+    end
+
+    add_index :subgeographic_hierarchies, [:ancestor_id, :descendant_id, :generations], unique: true, name: "subgeographic_anc_desc_idx"
+    add_index :subgeographic_hierarchies, [:descendant_id], name: "subgeographic_desc_idx"
+
+    Subgeographic.rebuild!
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_05_112244) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_06_111547) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -101,6 +101,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_112244) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "subgeographic_hierarchies", id: false, force: :cascade do |t|
+    t.uuid "ancestor_id", null: false
+    t.uuid "descendant_id", null: false
+    t.integer "generations", null: false
+    t.index ["ancestor_id", "descendant_id", "generations"], name: "subgeographic_anc_desc_idx", unique: true
+    t.index ["ancestor_id"], name: "index_subgeographic_hierarchies_on_ancestor_id"
+    t.index ["descendant_id"], name: "index_subgeographic_hierarchies_on_descendant_id"
+    t.index ["descendant_id"], name: "subgeographic_desc_idx"
+  end
+
   create_table "subgeographics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "subgeographic_geometry_id"
     t.uuid "parent_id"
@@ -121,6 +131,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_112244) do
   add_foreign_key "funder_subgeographics", "subgeographics", on_delete: :cascade
   add_foreign_key "funders", "subgeographics", column: "primary_office_country_id", on_delete: :cascade
   add_foreign_key "funders", "subgeographics", column: "primary_office_state_id", on_delete: :cascade
+  add_foreign_key "subgeographic_hierarchies", "subgeographics", column: "ancestor_id", on_delete: :cascade
+  add_foreign_key "subgeographic_hierarchies", "subgeographics", column: "descendant_id", on_delete: :cascade
   add_foreign_key "subgeographics", "subgeographic_geometries", on_delete: :cascade
   add_foreign_key "subgeographics", "subgeographics", column: "parent_id", on_delete: :cascade
 end

--- a/backend/spec/fixtures/snapshots/api/v1/funders.json
+++ b/backend/spec/fixtures/snapshots/api/v1/funders.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "62035fbd-19d3-4594-89bc-cfb6bedfc1bf",
+      "id": "516ad8ed-3d87-42c2-a6d3-18cb1236c679",
       "type": "funder",
       "attributes": {
         "name": "Elbert Denesik",
@@ -14,7 +14,7 @@
         "primary_contact_location": "851 Drusilla Lodge, Port Randy, VT 43075",
         "primary_contact_role": "intermediary",
         "website": "http://hilpert.biz/drusilla",
-        "date_joined_fora": "2022-02-10T00:00:00.000Z",
+        "date_joined_fora": "2022-02-11T00:00:00.000Z",
         "funder_type": "private_foundation",
         "funder_type_other": "Dolores fugiat nesciunt accusantium.",
         "capital_acceptances": [
@@ -40,7 +40,6 @@
         "capital_types_other": "Dolores fugiat nesciunt accusantium.",
         "spend_down_strategy": false,
         "areas": [
-          "soil_health",
           "food_sovereignty"
         ],
         "areas_other": "Dolores fugiat nesciunt accusantium.",
@@ -51,28 +50,40 @@
         "demographics_other": "Dolores fugiat nesciunt accusantium.",
         "contact_email": "lauren@ruecker.io",
         "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTVdJek9UZG1PUzB3TlRBNUxUUmlabVV0T1RZeU1DMDBaRFV6TkdNNE1EWmxOVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--65d84fc51516f9380a0b6226ac8c43c05dbc3e7f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTVdJek9UZG1PUzB3TlRBNUxUUmlabVV0T1RZeU1DMDBaRFV6TkdNNE1EWmxOVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--65d84fc51516f9380a0b6226ac8c43c05dbc3e7f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTVdJek9UZG1PUzB3TlRBNUxUUmlabVV0T1RZeU1DMDBaRFV6TkdNNE1EWmxOVElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--65d84fc51516f9380a0b6226ac8c43c05dbc3e7f/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpsbE4yUXhaUzAwWmpnNUxUUTRaRFV0T1dZMFpTMDJaVGRpTUdWaFpUaGlZakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab622041f785c10a3ce3c70ae0ee1629f4c68a84/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpsbE4yUXhaUzAwWmpnNUxUUTRaRFV0T1dZMFpTMDJaVGRpTUdWaFpUaGlZakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab622041f785c10a3ce3c70ae0ee1629f4c68a84/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrTXpsbE4yUXhaUzAwWmpnNUxUUTRaRFV0T1dZMFpTMDJaVGRpTUdWaFpUaGlZakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ab622041f785c10a3ce3c70ae0ee1629f4c68a84/picture.jpg"
         }
       },
       "relationships": {
         "primary_office_state": {
           "data": {
-            "id": "c101a0c9-fa3f-45a1-bd84-7c594a9eab5b",
+            "id": "dddfa73c-8684-4e84-b7b5-96ff926c6634",
             "type": "subgeographic"
           }
         },
         "primary_office_country": {
           "data": {
-            "id": "6abd521e-eb81-4a5a-aeb2-95a3d464a980",
+            "id": "a10fc488-770c-43c3-bbb4-e738f02dc753",
             "type": "subgeographic"
           }
         },
         "subgeographics": {
           "data": [
             {
-              "id": "a141686e-a5c8-46c1-8fce-a196db2cc6d7",
+              "id": "3714b5cd-469d-4134-bd92-2bf09490b09a",
+              "type": "subgeographic"
+            }
+          ]
+        },
+        "subgeographic_ancestors": {
+          "data": [
+            {
+              "id": "3714b5cd-469d-4134-bd92-2bf09490b09a",
+              "type": "subgeographic"
+            },
+            {
+              "id": "e74fdd77-50a5-4311-b9db-e278cddc9323",
               "type": "subgeographic"
             }
           ]
@@ -80,7 +91,7 @@
       }
     },
     {
-      "id": "550f6fd9-a2c1-4452-af07-1f7fb225a2f9",
+      "id": "db526705-41b7-4405-ab00-fd1dc4de62cd",
       "type": "funder",
       "attributes": {
         "name": "Msgr. Genaro Cronin",
@@ -93,7 +104,7 @@
         "primary_contact_location": "9628 Hegmann Square, Croninfort, NY 44573",
         "primary_contact_role": "funder",
         "website": "http://bartoletti.com/jeremiah_cronin",
-        "date_joined_fora": "2022-03-28T00:00:00.000Z",
+        "date_joined_fora": "2022-03-29T00:00:00.000Z",
         "funder_type": "loan_fund",
         "funder_type_other": "Placeat commodi libero et.",
         "capital_acceptances": [
@@ -119,8 +130,7 @@
         "capital_types_other": "Placeat commodi libero et.",
         "spend_down_strategy": true,
         "areas": [
-          "fermentation",
-          "soil_measurement_and_technology"
+          "equity_and_justice"
         ],
         "areas_other": "Placeat commodi libero et.",
         "demographics": [
@@ -130,21 +140,21 @@
         "demographics_other": "Placeat commodi libero et.",
         "contact_email": "desmond_herzog@example.org",
         "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTW1JME0yTmtaQzA1WmpnM0xUUXlZbU10T1dZME15MHdOek13WldZM1pEUTVZVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e76ace8afb5ee0a4868866429c207ac95d0bf3b7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTW1JME0yTmtaQzA1WmpnM0xUUXlZbU10T1dZME15MHdOek13WldZM1pEUTVZVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e76ace8afb5ee0a4868866429c207ac95d0bf3b7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTW1JME0yTmtaQzA1WmpnM0xUUXlZbU10T1dZME15MHdOek13WldZM1pEUTVZVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e76ace8afb5ee0a4868866429c207ac95d0bf3b7/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RJME1XWTBOQzB6TnpGa0xUUTJPVEl0T0RkaE1DMWtOMk0xTkRGa05tWTNOamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c348a5d09787472cb09395e10a84d90e024be7b6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RJME1XWTBOQzB6TnpGa0xUUTJPVEl0T0RkaE1DMWtOMk0xTkRGa05tWTNOamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c348a5d09787472cb09395e10a84d90e024be7b6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1RJME1XWTBOQzB6TnpGa0xUUTJPVEl0T0RkaE1DMWtOMk0xTkRGa05tWTNOamNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c348a5d09787472cb09395e10a84d90e024be7b6/picture.jpg"
         }
       },
       "relationships": {
         "primary_office_state": {
           "data": {
-            "id": "1f0f8a90-94b3-473b-a3e7-395d464e9a7d",
+            "id": "c43b3e67-2e78-44ad-b8a7-74f89d1106fc",
             "type": "subgeographic"
           }
         },
         "primary_office_country": {
           "data": {
-            "id": "7eb60a81-9a9f-45b9-b000-31c23dd3e992",
+            "id": "cb8c2e2c-2bac-4610-aa95-9626ab364052",
             "type": "subgeographic"
           }
         },
@@ -152,11 +162,16 @@
           "data": [
 
           ]
+        },
+        "subgeographic_ancestors": {
+          "data": [
+
+          ]
         }
       }
     },
     {
-      "id": "fe4814b9-9cf7-4b4e-80c8-5613f3fe9fd5",
+      "id": "c2403e96-82f8-479f-a895-d5ce68932e05",
       "type": "funder",
       "attributes": {
         "name": "Otha Kemmer",
@@ -169,7 +184,7 @@
         "primary_contact_location": "Suite 995 11769 Ariane Ridge, Port Rolf, WY 06997-6910",
         "primary_contact_role": "regrantor",
         "website": "http://kutch-spencer.com/moises",
-        "date_joined_fora": "2021-11-17T00:00:00.000Z",
+        "date_joined_fora": "2021-11-18T00:00:00.000Z",
         "funder_type": "funder_collaborative_or_network",
         "funder_type_other": "Enim repellat pariatur est.",
         "capital_acceptances": [
@@ -195,8 +210,7 @@
         "capital_types_other": "Enim repellat pariatur est.",
         "spend_down_strategy": true,
         "areas": [
-          "land_asset_financing",
-          "capacity_building"
+          "equity_and_justice"
         ],
         "areas_other": "Enim repellat pariatur est.",
         "demographics": [
@@ -206,21 +220,21 @@
         "demographics_other": "Enim repellat pariatur est.",
         "contact_email": "dawna.block@example.org",
         "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWkdJd05ERXpOaTFsTjJNeUxUUTRaR1l0WVdNMll5MDNNVEU0WWpKak1tVm1PRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c3c8692e33eb5c13895a34432b528619ed1794a1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWkdJd05ERXpOaTFsTjJNeUxUUTRaR1l0WVdNMll5MDNNVEU0WWpKak1tVm1PRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c3c8692e33eb5c13895a34432b528619ed1794a1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWkdJd05ERXpOaTFsTjJNeUxUUTRaR1l0WVdNMll5MDNNVEU0WWpKak1tVm1PRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c3c8692e33eb5c13895a34432b528619ed1794a1/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WVRZd01tSmxPUzB5T0RFMkxUUTVNakV0T0Rkak15MWhOMll4WTJNeE1tUmlNMkVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0466b864b223877f199aae1555cbe06ec2fe2678/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WVRZd01tSmxPUzB5T0RFMkxUUTVNakV0T0Rkak15MWhOMll4WTJNeE1tUmlNMkVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0466b864b223877f199aae1555cbe06ec2fe2678/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WVRZd01tSmxPUzB5T0RFMkxUUTVNakV0T0Rkak15MWhOMll4WTJNeE1tUmlNMkVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0466b864b223877f199aae1555cbe06ec2fe2678/picture.jpg"
         }
       },
       "relationships": {
         "primary_office_state": {
           "data": {
-            "id": "f153533a-dd9a-4a52-ada7-4394752bd735",
+            "id": "9a32c3a0-3949-43f5-8f92-a078d6e33697",
             "type": "subgeographic"
           }
         },
         "primary_office_country": {
           "data": {
-            "id": "05e74ed6-b738-404c-8c84-80e4b5fe615f",
+            "id": "223605f9-b9aa-4fc0-a964-f6fe4feedc7d",
             "type": "subgeographic"
           }
         },
@@ -228,11 +242,16 @@
           "data": [
 
           ]
+        },
+        "subgeographic_ancestors": {
+          "data": [
+
+          ]
         }
       }
     },
     {
-      "id": "be56eae5-f5df-48d1-bad6-6c6d160b4949",
+      "id": "49c6dfec-8d3a-4fb6-a04a-6854cbd60a6c",
       "type": "funder",
       "attributes": {
         "name": "Raymon Wisoky",
@@ -245,7 +264,7 @@
         "primary_contact_location": "48805 Haley Turnpike, Hesselmouth, MI 60478-1622",
         "primary_contact_role": "intermediary",
         "website": "http://hane.com/jules",
-        "date_joined_fora": "2022-03-12T00:00:00.000Z",
+        "date_joined_fora": "2022-03-13T00:00:00.000Z",
         "funder_type": "private_foundation",
         "funder_type_other": "Et quaerat omnis veniam.",
         "capital_acceptances": [
@@ -271,8 +290,7 @@
         "capital_types_other": "Et quaerat omnis veniam.",
         "spend_down_strategy": false,
         "areas": [
-          "agroforestry",
-          "education_future_farmers_young_farmers"
+          "equity_and_justice"
         ],
         "areas_other": "Et quaerat omnis veniam.",
         "demographics": [
@@ -282,25 +300,30 @@
         "demographics_other": "Et quaerat omnis veniam.",
         "contact_email": "jules_keeling@grimes-stokes.co",
         "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT1dNMFpHWTFaaTFqTVdVekxUUmxNVFl0T1RCbU55MDROakkzTldKak1HTTROVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--606a1a66c40287fd2e578cd8fc18d7c52ab62cdc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT1dNMFpHWTFaaTFqTVdVekxUUmxNVFl0T1RCbU55MDROakkzTldKak1HTTROVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--606a1a66c40287fd2e578cd8fc18d7c52ab62cdc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsT1dNMFpHWTFaaTFqTVdVekxUUmxNVFl0T1RCbU55MDROakkzTldKak1HTTROVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--606a1a66c40287fd2e578cd8fc18d7c52ab62cdc/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWWpFeE5qVmlNaTA0T1RaakxUUmlaR1F0T1RZNVppMHhPVEV6TW1JeE56UTBPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--da47442948856350e4a16f71a68a471197da6d54/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWWpFeE5qVmlNaTA0T1RaakxUUmlaR1F0T1RZNVppMHhPVEV6TW1JeE56UTBPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--da47442948856350e4a16f71a68a471197da6d54/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqWWpFeE5qVmlNaTA0T1RaakxUUmlaR1F0T1RZNVppMHhPVEV6TW1JeE56UTBPRFVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--da47442948856350e4a16f71a68a471197da6d54/picture.jpg"
         }
       },
       "relationships": {
         "primary_office_state": {
           "data": {
-            "id": "b64c7d9d-9179-46d4-a707-64dd134a79ae",
+            "id": "c5e448ae-46a2-4ddc-9895-9d33e15d3357",
             "type": "subgeographic"
           }
         },
         "primary_office_country": {
           "data": {
-            "id": "a9988785-f1c7-47db-ac41-3fe93df0800e",
+            "id": "a7ea70c8-91f7-48a0-80b9-1ce343d091f4",
             "type": "subgeographic"
           }
         },
         "subgeographics": {
+          "data": [
+
+          ]
+        },
+        "subgeographic_ancestors": {
           "data": [
 
           ]

--- a/backend/spec/fixtures/snapshots/api/v1/get-funder.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-funder.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "a68ff090-6cb0-4285-a5de-e456e71c4334",
+    "id": "57c563ef-9ca0-44a5-8fd1-8b24b606f438",
     "type": "funder",
     "attributes": {
       "name": "Otha Kemmer",
@@ -13,7 +13,7 @@
       "primary_contact_location": "Suite 995 11769 Ariane Ridge, Port Rolf, WY 06997-6910",
       "primary_contact_role": "regrantor",
       "website": "http://kutch-spencer.com/moises",
-      "date_joined_fora": "2021-11-17T00:00:00.000Z",
+      "date_joined_fora": "2021-11-18T00:00:00.000Z",
       "funder_type": "funder_collaborative_or_network",
       "funder_type_other": "Enim repellat pariatur est.",
       "capital_acceptances": [
@@ -50,28 +50,40 @@
       "demographics_other": "Enim repellat pariatur est.",
       "contact_email": "dawna.block@example.org",
       "logo": {
-        "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TWpreE5EUXdOUzFtTVdWbExUUmlORGt0WVRRMFlpMWhPV1E1WmpJNVpUSmxPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--aface1ef3b1f1ce658e921d26d44f70aac6b8c4b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-        "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TWpreE5EUXdOUzFtTVdWbExUUmlORGt0WVRRMFlpMWhPV1E1WmpJNVpUSmxPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--aface1ef3b1f1ce658e921d26d44f70aac6b8c4b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-        "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6TWpreE5EUXdOUzFtTVdWbExUUmlORGt0WVRRMFlpMWhPV1E1WmpJNVpUSmxPVGdHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--aface1ef3b1f1ce658e921d26d44f70aac6b8c4b/picture.jpg"
+        "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1dJd01XSmhaaTB3WVRObUxUUXhNMlV0WVRBMFpTMW1PV0U1TjJKbU5XTmpOeklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7810411701695fbd02236013fdcb64b43b841f0a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+        "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1dJd01XSmhaaTB3WVRObUxUUXhNMlV0WVRBMFpTMW1PV0U1TjJKbU5XTmpOeklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7810411701695fbd02236013fdcb64b43b841f0a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+        "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T1dJd01XSmhaaTB3WVRObUxUUXhNMlV0WVRBMFpTMW1PV0U1TjJKbU5XTmpOeklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7810411701695fbd02236013fdcb64b43b841f0a/picture.jpg"
       }
     },
     "relationships": {
       "primary_office_state": {
         "data": {
-          "id": "83dc614d-4479-4cf3-9dcb-70df0c20a183",
+          "id": "7e21731c-fd69-41a0-acc0-4f15f8c685cd",
           "type": "subgeographic"
         }
       },
       "primary_office_country": {
         "data": {
-          "id": "7577eb8b-08b3-459f-a081-a5d5ad78b02d",
+          "id": "05e8fa15-067c-42bc-b04d-ea7ddd272e34",
           "type": "subgeographic"
         }
       },
       "subgeographics": {
         "data": [
           {
-            "id": "37f105b8-c41d-4f16-bd22-8e7bcdd52572",
+            "id": "e2656dab-ec60-499f-996a-fc358608f19e",
+            "type": "subgeographic"
+          }
+        ]
+      },
+      "subgeographic_ancestors": {
+        "data": [
+          {
+            "id": "e2656dab-ec60-499f-996a-fc358608f19e",
+            "type": "subgeographic"
+          },
+          {
+            "id": "cf6adeec-673c-43d7-9b08-e3219885b97b",
             "type": "subgeographic"
           }
         ]

--- a/backend/spec/models/funder_spec.rb
+++ b/backend/spec/models/funder_spec.rb
@@ -90,4 +90,40 @@ RSpec.describe Funder, type: :model do
   include_examples :static_relation_validations, attribute: :capital_types, presence: true
   include_examples :static_relation_validations, attribute: :areas, presence: true
   include_examples :static_relation_validations, attribute: :demographics, presence: true
+
+  describe "scopes" do
+    describe ".for_subgeographics" do
+      let!(:country) { create :subgeographic, geographic: :countries }
+      let!(:region) { create :subgeographic, geographic: :regions, parent: country }
+
+      let!(:correct_funder) { create :funder, subgeographics: [region] }
+      let!(:ignored_funder) { create :funder }
+
+      it "returns correct result for current subgeographic" do
+        expect(Funder.for_subgeographics(region)).to eq([correct_funder])
+      end
+
+      it "returns correct result for ancestor subgeographic" do
+        expect(Funder.for_subgeographics(country)).to eq([correct_funder])
+      end
+    end
+
+    describe ".for_geographics" do
+      let!(:country) { create :subgeographic, geographic: :countries }
+      let!(:region) { create :subgeographic, geographic: :regions, parent: country }
+      let!(:national) { create :subgeographic, geographic: :national, parent: country }
+
+      let!(:funder_1) { create :funder, subgeographics: [region] }
+      let!(:funder_2) { create :funder, subgeographics: [national] }
+
+      it "returns correct result for current geographic" do
+        expect(Funder.for_geographics(:regions)).to eq([funder_1])
+        expect(Funder.for_geographics(:national)).to eq([funder_2])
+      end
+
+      it "returns correct result for ancestor geographic" do
+        expect(Funder.for_geographics(:countries)).to eq([funder_1, funder_2])
+      end
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/funders_spec.rb
+++ b/backend/spec/requests/api/v1/funders_spec.rb
@@ -6,13 +6,20 @@ RSpec.describe "API V1 Funders", type: :request do
       tags "Funders"
       consumes "application/json"
       produces "application/json"
+      parameter name: "filter[subgeographic_ids]", in: :query, type: :array, items: {type: :string}, description: "Filter results only for specified subgeographics", required: false
+      parameter name: "filter[geographics]", in: :query, type: :array, items: {type: :string}, description: "Filter results only for specified geographics", required: false
+      parameter name: "filter[areas]", in: :query, type: :array, items: {type: :string, enum: Area::TYPES}, description: "Filter results only for specified areas", required: false
+      parameter name: "filter[demographics]", in: :query, type: :array, items: {type: :string, enum: Demographic::TYPES}, description: "Filter results only for specified demographics", required: false
+      parameter name: "filter[funder_types]", in: :query, type: :array, items: {type: :string, enum: FunderType::TYPES}, description: "Filter results only for specified funder types", required: false
+      parameter name: "filter[capital_types]", in: :query, type: :array, items: {type: :string, enum: CapitalType::TYPES}, description: "Filter results only for specified capital types", required: false
+      parameter name: "filter[funder_legal_status]", in: :query, type: :string, enum: FunderLegalStatus::TYPES, description: "Filter results only for specified funder legal status", required: false
       parameter name: "fields[funder]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
       parameter name: :includes, in: :query, type: :string, description: "Include relationships. Use comma to separate multiple fields", required: false
 
       let(:country) { create :subgeographic, geographic: :countries }
       let!(:national) { create :subgeographic, geographic: :national, parent: country }
-      let!(:funders) { create_list :funder, 3 }
-      let!(:funder) { create :funder, subgeographics: [national] }
+      let!(:funders) { create_list :funder, 3, areas: ["equity_and_justice"] }
+      let!(:funder) { create :funder, subgeographics: [national], areas: ["food_sovereignty"] }
 
       response "200", :success do
         schema type: :object, properties: {
@@ -39,6 +46,40 @@ RSpec.describe "API V1 Funders", type: :request do
 
           it "matches snapshot" do
             expect(response.body).to match_snapshot("api/v1/funders-include-relationships")
+          end
+        end
+
+        context "when filtered for specific subgeographics" do
+          let("filter[subgeographic_ids]") { [national.id] }
+
+          it "returns only funders with correct subgeographics" do
+            expect(response_json["data"].pluck("id")).to eq([funder.id])
+          end
+        end
+
+        context "when filtered for specific geographics" do
+          let("filter[geographics]") { [:national] }
+
+          it "returns only funders with correct geographics" do
+            expect(response_json["data"].pluck("id")).to eq([funder.id])
+          end
+        end
+
+        context "when filtered for specified enums" do
+          let("filter[areas]") { ["food_sovereignty"] }
+
+          it "returns only funders at correct areas" do
+            expect(response_json["data"].pluck("id")).to eq([funder.id])
+          end
+        end
+
+        context "when combining multiple filters" do
+          let("filter[subgeographic_ids]") { [national.id] }
+          let("filter[geographics]") { [:national] }
+          let("filter[areas]") { ["food_sovereignty"] }
+
+          it "returns only funders which are true for all filters" do
+            expect(response_json["data"].pluck("id")).to eq([funder.id])
           end
         end
       end

--- a/backend/spec/services/api/enum_filter_spec.rb
+++ b/backend/spec/services/api/enum_filter_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe API::EnumFilter do
+  subject { described_class.new query, filters }
+
+  describe "#call" do
+    let!(:correct_funder) do
+      create :funder, areas: %w[equity_and_justice food_sovereignty], demographics: %w[black_or_african_american]
+    end
+    let!(:different_areas_funder) do
+      create :funder, areas: %w[climate_change], demographics: %w[black_or_african_american]
+    end
+    let!(:different_demographics_funder) do
+      create :funder, areas: %w[food_sovereignty], demographics: %w[women]
+    end
+    let!(:ignored_funder) do
+      create :funder, areas: %w[equity_and_justice food_sovereignty], demographics: %w[black_or_african_american]
+    end
+
+    let(:query) do
+      Funder.where id: [correct_funder.id, different_areas_funder.id, different_demographics_funder.id]
+    end
+    let(:filters) { {areas: %w[food_sovereignty], demographic: %w[black_or_african_american]} }
+
+    it "returns correct funder" do
+      expect(subject.call).to eq([correct_funder])
+    end
+  end
+end

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -69,7 +69,8 @@ RSpec.configure do |config|
                 properties: {
                   primary_office_state: {"$ref" => "#/components/schemas/nullable_response_relation"},
                   primary_office_country: {"$ref" => "#/components/schemas/response_relation"},
-                  subgeographics: {"$ref" => "#/components/schemas/response_relations"}
+                  subgeographics: {"$ref" => "#/components/schemas/response_relations"},
+                  subgeographic_ancestors: {"$ref" => "#/components/schemas/response_relations"}
                 }
               }
             },

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -521,6 +521,150 @@ paths:
       tags:
       - Funders
       parameters:
+      - name: filter[subgeographic_ids]
+        in: query
+        items:
+          type: string
+        description: Filter results only for specified subgeographics
+        required: false
+        schema:
+          type: array
+      - name: filter[geographics]
+        in: query
+        items:
+          type: string
+        description: Filter results only for specified geographics
+        required: false
+        schema:
+          type: array
+      - name: filter[areas]
+        in: query
+        items:
+          type: string
+          enum:
+          - equity_and_justice
+          - food_sovereignty
+          - rural_economic_health
+          - climate_change
+          - grazing
+          - soil_health
+          - water
+          - biodiversity
+          - land_access
+          - policy_advocacy
+          - movement_building
+          - nutrient_quality_density
+          - research
+          - animal_welfare
+          - aquaculture
+          - soil_measurement_and_technology
+          - middle_of_the_supply_chain_infrastructure
+          - fiber_systems
+          - toxins_reduction
+          - media_communications_narrative_building
+          - technical_assistance_and_business_planning
+          - regenerative_ag_financing
+          - true_cost_accounting
+          - education_youth
+          - education_future_farmers_young_farmers
+          - healthy_food_access
+          - supply_chain_and_market_development
+          - tribal_nations
+          - leadership_development
+          - educating_legislators
+          - policy_lobbying
+          - farm_workers
+          - urban_farming
+          - regenerative_ag_organizing_networks_or_groups
+          - sustainable_or_biological_inputs
+          - on_farm_automation
+          - farm_equipment
+          - land_asset_financing
+          - land_conservation
+          - land_transition
+          - fermentation
+          - alternative_proteins
+          - agroforestry
+          - consumer_packaged_goods
+          - capacity_building
+          - other
+        description: Filter results only for specified areas
+        required: false
+        schema:
+          type: array
+      - name: filter[demographics]
+        in: query
+        items:
+          type: string
+          enum:
+          - black_or_african_american
+          - indigenous_tribal_nations
+          - women
+          - youth
+          - asian
+          - hispanic_or_latinx
+          - lgbtq
+          - white
+          - no_specific_focus
+          - other
+          - i_dont_know
+        description: Filter results only for specified demographics
+        required: false
+        schema:
+          type: array
+      - name: filter[funder_types]
+        in: query
+        items:
+          type: string
+          enum:
+          - accelerator
+          - advisory
+          - bank
+          - educational_land_based
+          - family_office
+          - funder_collaborative_or_network
+          - individual
+          - initiative
+          - loan_fund
+          - network_of_funders
+          - private_foundation
+          - public_foundation
+          - regrantor
+          - other
+        description: Filter results only for specified funder types
+        required: false
+        schema:
+          type: array
+      - name: filter[capital_types]
+        in: query
+        items:
+          type: string
+          enum:
+          - grants
+          - debt
+          - equity
+          - pris
+          - mris
+          - re_grants
+          - forgivable_loans
+          - guarantees
+        description: Filter results only for specified capital types
+        required: false
+        schema:
+          type: array
+      - name: filter[funder_legal_status]
+        in: query
+        enum:
+        - for_profit
+        - government_organization
+        - individual
+        - non_profit
+        - research_institution
+        - other
+        description: Filter results only for specified funder legal status
+        required: false
+        schema:
+          type: string
       - name: fields[funder]
         in: query
         description: Get only required fields. Use comma to separate multiple fields
@@ -540,7 +684,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: d45053a1-95bf-48a6-9205-0b79c9612372
+                - id: c903dec3-e580-4cd9-84c1-93588ae3bba7
                   type: funder
                   attributes:
                     name: Elbert Denesik
@@ -554,7 +698,7 @@ paths:
                     primary_contact_location: 851 Drusilla Lodge, Port Randy, VT 43075
                     primary_contact_role: intermediary
                     website: http://hilpert.biz/drusilla
-                    date_joined_fora: '2022-02-10T00:00:00.000Z'
+                    date_joined_fora: '2022-02-11T00:00:00.000Z'
                     funder_type: private_foundation
                     funder_type_other: Dolores fugiat nesciunt accusantium.
                     capital_acceptances:
@@ -578,7 +722,6 @@ paths:
                     capital_types_other: Dolores fugiat nesciunt accusantium.
                     spend_down_strategy: false
                     areas:
-                    - soil_health
                     - food_sovereignty
                     areas_other: Dolores fugiat nesciunt accusantium.
                     demographics:
@@ -587,23 +730,29 @@ paths:
                     demographics_other: Dolores fugiat nesciunt accusantium.
                     contact_email: lauren@ruecker.io
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVRoalkyWTVaQzFpTkRBM0xUUTRNMlF0T1dNelppMWlOekl5TW1aaVlURmpaaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2addff1ac6f002ee96493e7d51ee06defeca4648/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVRoalkyWTVaQzFpTkRBM0xUUTRNMlF0T1dNelppMWlOekl5TW1aaVlURmpaaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2addff1ac6f002ee96493e7d51ee06defeca4648/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVRoalkyWTVaQzFpTkRBM0xUUTRNMlF0T1dNelppMWlOekl5TW1aaVlURmpaaklHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2addff1ac6f002ee96493e7d51ee06defeca4648/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WlRObVpETTFOUzFqWkRjNUxUUXdZbUV0T1RFNE5TMWpNamN6WVRGbE1XWXdNV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e63891ee41d4d618615e4db0a1acc5db29b10533/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WlRObVpETTFOUzFqWkRjNUxUUXdZbUV0T1RFNE5TMWpNamN6WVRGbE1XWXdNV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e63891ee41d4d618615e4db0a1acc5db29b10533/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0WlRObVpETTFOUzFqWkRjNUxUUXdZbUV0T1RFNE5TMWpNamN6WVRGbE1XWXdNV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e63891ee41d4d618615e4db0a1acc5db29b10533/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: daea9b09-a543-4d12-9d1e-ab22869f8443
+                        id: 386d6b45-b442-4c5a-9d67-1d7d4c93e57f
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: df8d7de9-79e8-4903-9033-d3895de62395
+                        id: 5d4a5877-359d-420a-b23c-e3450813b5b7
                         type: subgeographic
                     subgeographics:
                       data:
-                      - id: 5bc38148-e5bc-466d-b6c6-6fd791d192f2
+                      - id: 1934d7bd-4182-4d7f-8c77-3fa69b34a200
                         type: subgeographic
-                - id: '053587c9-a08e-4eaa-8b54-cd7f93ba095c'
+                    subgeographic_ancestors:
+                      data:
+                      - id: 1934d7bd-4182-4d7f-8c77-3fa69b34a200
+                        type: subgeographic
+                      - id: f778727b-871d-44e7-ab4d-17658490b000
+                        type: subgeographic
+                - id: 1e6673a0-71bd-49e0-bbaf-b945fb62416c
                   type: funder
                   attributes:
                     name: Msgr. Genaro Cronin
@@ -618,7 +767,7 @@ paths:
                       44573
                     primary_contact_role: funder
                     website: http://bartoletti.com/jeremiah_cronin
-                    date_joined_fora: '2022-03-28T00:00:00.000Z'
+                    date_joined_fora: '2022-03-29T00:00:00.000Z'
                     funder_type: loan_fund
                     funder_type_other: Placeat commodi libero et.
                     capital_acceptances:
@@ -642,8 +791,7 @@ paths:
                     capital_types_other: Placeat commodi libero et.
                     spend_down_strategy: true
                     areas:
-                    - fermentation
-                    - soil_measurement_and_technology
+                    - equity_and_justice
                     areas_other: Placeat commodi libero et.
                     demographics:
                     - no_specific_focus
@@ -651,21 +799,23 @@ paths:
                     demographics_other: Placeat commodi libero et.
                     contact_email: desmond_herzog@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVdZNE5UVXlPUzAyTlRnMkxUUm1NemN0WVdKa1pDMHdPV1JsTWpjeU5ERXlOek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5cd4670930b3ad66a1a1d0ac98023fda2ba94b50/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVdZNE5UVXlPUzAyTlRnMkxUUm1NemN0WVdKa1pDMHdPV1JsTWpjeU5ERXlOek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5cd4670930b3ad66a1a1d0ac98023fda2ba94b50/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTVdZNE5UVXlPUzAyTlRnMkxUUm1NemN0WVdKa1pDMHdPV1JsTWpjeU5ERXlOek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5cd4670930b3ad66a1a1d0ac98023fda2ba94b50/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WldZd01tVmtZaTFpTmpsakxUUmlOMlV0T0RFMVlpMHpOMlJoTVRJMFpEWTBOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--96caba84557a756ee565bac899f8c9ffb5e4d1e8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WldZd01tVmtZaTFpTmpsakxUUmlOMlV0T0RFMVlpMHpOMlJoTVRJMFpEWTBOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--96caba84557a756ee565bac899f8c9ffb5e4d1e8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WldZd01tVmtZaTFpTmpsakxUUmlOMlV0T0RFMVlpMHpOMlJoTVRJMFpEWTBOalFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--96caba84557a756ee565bac899f8c9ffb5e4d1e8/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: cc0446be-cb94-4652-9683-d82f7c369310
+                        id: ae59c771-3693-4bf8-a4a7-eb779f524981
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: 84ff718c-ac63-4363-836d-e2c56f86ab93
+                        id: 95eda091-5a46-4be5-9890-3ab03266dc9f
                         type: subgeographic
                     subgeographics:
                       data: []
-                - id: cbe325c0-34e3-4718-84e0-46854f664b8b
+                    subgeographic_ancestors:
+                      data: []
+                - id: ce614306-0f25-44eb-b084-1065c80f2db3
                   type: funder
                   attributes:
                     name: Otha Kemmer
@@ -680,7 +830,7 @@ paths:
                       WY 06997-6910
                     primary_contact_role: regrantor
                     website: http://kutch-spencer.com/moises
-                    date_joined_fora: '2021-11-17T00:00:00.000Z'
+                    date_joined_fora: '2021-11-18T00:00:00.000Z'
                     funder_type: funder_collaborative_or_network
                     funder_type_other: Enim repellat pariatur est.
                     capital_acceptances:
@@ -704,8 +854,7 @@ paths:
                     capital_types_other: Enim repellat pariatur est.
                     spend_down_strategy: true
                     areas:
-                    - land_asset_financing
-                    - capacity_building
+                    - equity_and_justice
                     areas_other: Enim repellat pariatur est.
                     demographics:
                     - hispanic_or_latinx
@@ -713,21 +862,23 @@ paths:
                     demographics_other: Enim repellat pariatur est.
                     contact_email: dawna.block@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WmpNeU9USTFOUzAwWXpVeUxUUmhZemt0T1RabE1pMDBNemd3WldSaE1EZG1aV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e18a3e1cd0bb327e4e928dc99c71f7d288659284/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WmpNeU9USTFOUzAwWXpVeUxUUmhZemt0T1RabE1pMDBNemd3WldSaE1EZG1aV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e18a3e1cd0bb327e4e928dc99c71f7d288659284/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WmpNeU9USTFOUzAwWXpVeUxUUmhZemt0T1RabE1pMDBNemd3WldSaE1EZG1aV01HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--e18a3e1cd0bb327e4e928dc99c71f7d288659284/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTUdJd01EazBaQzB4WTJFekxUUTBZamd0T1RNNE15MDNZelExT0dObVkyVmtaallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--085b49edfdaf83e7e62a3d2a79c92174b0b8c6d6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTUdJd01EazBaQzB4WTJFekxUUTBZamd0T1RNNE15MDNZelExT0dObVkyVmtaallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--085b49edfdaf83e7e62a3d2a79c92174b0b8c6d6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsTUdJd01EazBaQzB4WTJFekxUUTBZamd0T1RNNE15MDNZelExT0dObVkyVmtaallHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--085b49edfdaf83e7e62a3d2a79c92174b0b8c6d6/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: a755c80e-d925-4e35-96a6-f2fa73bc7b98
+                        id: a8afd420-3ec1-4aff-a5d8-a324f2cafdfe
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: e035e8a9-2aba-45ad-879b-64dd8d655b03
+                        id: 376e6c8d-652e-4126-b256-bfd11c999da4
                         type: subgeographic
                     subgeographics:
                       data: []
-                - id: 7d4e5f7b-271f-4177-98d4-972b9b19286e
+                    subgeographic_ancestors:
+                      data: []
+                - id: 48540d57-6769-4f60-84ee-4f52ba7fe19b
                   type: funder
                   attributes:
                     name: Raymon Wisoky
@@ -742,7 +893,7 @@ paths:
                       60478-1622
                     primary_contact_role: intermediary
                     website: http://hane.com/jules
-                    date_joined_fora: '2022-03-12T00:00:00.000Z'
+                    date_joined_fora: '2022-03-13T00:00:00.000Z'
                     funder_type: private_foundation
                     funder_type_other: Et quaerat omnis veniam.
                     capital_acceptances:
@@ -766,8 +917,7 @@ paths:
                     capital_types_other: Et quaerat omnis veniam.
                     spend_down_strategy: false
                     areas:
-                    - agroforestry
-                    - education_future_farmers_young_farmers
+                    - equity_and_justice
                     areas_other: Et quaerat omnis veniam.
                     demographics:
                     - i_dont_know
@@ -775,19 +925,21 @@ paths:
                     demographics_other: Et quaerat omnis veniam.
                     contact_email: jules_keeling@grimes-stokes.co
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTVdNd1pqWTVaUzFqWkRVM0xUUXdZall0T1RSa1ppMHpOVGMxWVRNek1tUmpZellHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--71071df9b737b193bad78b64ba07da7f78a35e51/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTVdNd1pqWTVaUzFqWkRVM0xUUXdZall0T1RSa1ppMHpOVGMxWVRNek1tUmpZellHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--71071df9b737b193bad78b64ba07da7f78a35e51/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTVdNd1pqWTVaUzFqWkRVM0xUUXdZall0T1RSa1ppMHpOVGMxWVRNek1tUmpZellHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--71071df9b737b193bad78b64ba07da7f78a35e51/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WlRobE5tSTVZaTA0TXpsa0xUUmhPV1l0WWpZNU1pMDJZV05oTkdFeE1tSmpaVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--10991d14acc25d0ff88e6842770e03ca07477037/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WlRobE5tSTVZaTA0TXpsa0xUUmhPV1l0WWpZNU1pMDJZV05oTkdFeE1tSmpaVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--10991d14acc25d0ff88e6842770e03ca07477037/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1WlRobE5tSTVZaTA0TXpsa0xUUmhPV1l0WWpZNU1pMDJZV05oTkdFeE1tSmpaVE1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--10991d14acc25d0ff88e6842770e03ca07477037/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 4d833cfb-28fc-4c55-bad1-e2f7d5bc9fb0
+                        id: c64171b3-526c-4f44-bdc7-90e57644a634
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: 35cf42f3-0521-42e7-a00d-f3ce715263db
+                        id: 5ff581c4-e77b-4bee-b94d-ae8ac824b6a0
                         type: subgeographic
                     subgeographics:
+                      data: []
+                    subgeographic_ancestors:
                       data: []
               schema:
                 type: object
@@ -836,7 +988,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 5c3f3ce8-74a4-4a3f-88a7-2e1f71de60a8
+                  id: f2032613-0cbb-4722-8122-87db6c6e1a3e
                   type: funder
                   attributes:
                     name: Otha Kemmer
@@ -851,7 +1003,7 @@ paths:
                       WY 06997-6910
                     primary_contact_role: regrantor
                     website: http://kutch-spencer.com/moises
-                    date_joined_fora: '2021-11-17T00:00:00.000Z'
+                    date_joined_fora: '2021-11-18T00:00:00.000Z'
                     funder_type: funder_collaborative_or_network
                     funder_type_other: Enim repellat pariatur est.
                     capital_acceptances:
@@ -884,21 +1036,27 @@ paths:
                     demographics_other: Enim repellat pariatur est.
                     contact_email: dawna.block@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWVRjMk56QXdNaTA0WWpFeExUUTNaR0V0WW1SaU9DMDRNMlZqTXpBeE16Z3lOR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fffb41756698bab8a05cebe917ea2ef7c4a641bf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWVRjMk56QXdNaTA0WWpFeExUUTNaR0V0WW1SaU9DMDRNMlZqTXpBeE16Z3lOR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fffb41756698bab8a05cebe917ea2ef7c4a641bf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWVRjMk56QXdNaTA0WWpFeExUUTNaR0V0WW1SaU9DMDRNMlZqTXpBeE16Z3lOR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--fffb41756698bab8a05cebe917ea2ef7c4a641bf/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkdGaU5XVmlOQzAxWmpWaExUUXhZek10WVRZeVlpMWxNV0UxWldaaE4yWTJORGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a16f53880f126a2ac8f797750cc0a1ec72f53fdd/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkdGaU5XVmlOQzAxWmpWaExUUXhZek10WVRZeVlpMWxNV0UxWldaaE4yWTJORGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a16f53880f126a2ac8f797750cc0a1ec72f53fdd/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTkdGaU5XVmlOQzAxWmpWaExUUXhZek10WVRZeVlpMWxNV0UxWldaaE4yWTJORGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a16f53880f126a2ac8f797750cc0a1ec72f53fdd/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 2f5306a5-fd1f-4bf4-bba6-f9c8a3469c51
+                        id: a56ee66b-51b8-4c7f-991c-e98c23a7fdd0
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: 3c29456e-ef76-4ab0-adb9-2429d3469f47
+                        id: 5bf649c9-1f9b-4af7-8b97-4e2083fe05d8
                         type: subgeographic
                     subgeographics:
                       data:
-                      - id: 50e2a3aa-f58c-468e-a1c1-40b33f55d033
+                      - id: 0041537c-b128-40b4-8c73-6a62a3a97a41
+                        type: subgeographic
+                    subgeographic_ancestors:
+                      data:
+                      - id: 0041537c-b128-40b4-8c73-6a62a3a97a41
+                        type: subgeographic
+                      - id: 25b49057-40ea-4179-bab8-f3a3d9afc69b
                         type: subgeographic
               schema:
                 type: object
@@ -1068,33 +1226,33 @@ paths:
             application/json:
               example:
                 data:
-                - id: d198ac8f-2ba4-4ee4-883d-70cfa238d662
+                - id: fcc1705e-ce2c-4dc3-a351-00c7d3fafc1c
                   type: subgeographic
                   attributes:
                     name: Canada
                     code: Canada
                     geographic: countries
-                    created_at: '2022-10-06T09:52:34.165Z'
-                    updated_at: '2022-10-06T09:52:34.165Z'
+                    created_at: '2022-10-07T09:53:46.378Z'
+                    updated_at: '2022-10-07T09:53:46.378Z'
                   relationships:
                     parent:
                       data:
                     subgeographics:
                       data:
-                      - id: ebe0f2bb-5b6a-4c17-833e-8164c2b26a1f
+                      - id: 8c09e9c5-1336-438f-aa6a-e1f0ae14ef70
                         type: subgeographic
-                - id: ebe0f2bb-5b6a-4c17-833e-8164c2b26a1f
+                - id: 8c09e9c5-1336-438f-aa6a-e1f0ae14ef70
                   type: subgeographic
                   attributes:
                     name: Papua New Guinea
                     code: Papua New Guinea
                     geographic: regions
-                    created_at: '2022-10-06T09:52:34.183Z'
-                    updated_at: '2022-10-06T09:52:34.183Z'
+                    created_at: '2022-10-07T09:53:46.395Z'
+                    updated_at: '2022-10-07T09:53:46.395Z'
                   relationships:
                     parent:
                       data:
-                        id: d198ac8f-2ba4-4ee4-883d-70cfa238d662
+                        id: fcc1705e-ce2c-4dc3-a351-00c7d3fafc1c
                         type: subgeographic
                     subgeographics:
                       data: []
@@ -1140,10 +1298,10 @@ paths:
                       - - 0
                         - 0
                   properties:
-                    id: 3d96382a-fef4-4f81-8e25-36e51ed3e5f7
+                    id: 6c8bba9d-6549-4f44-8602-cc56ab5e72cd
                     code: Papua New Guinea
                     name: Papua New Guinea
-                    parent_id: 1492a775-c51f-45a7-a18e-54bb66e83ab6
+                    parent_id: baff2f81-9396-463a-a076-fd8ead561b84
                 - type: Feature
                   geometry:
                     type: Polygon
@@ -1159,10 +1317,10 @@ paths:
                       - - 0
                         - 0
                   properties:
-                    id: fbeffb8f-97c8-4514-81b2-05b07501509c
+                    id: e9ed5420-784e-4a4f-a86e-f4b9938f9e12
                     code: Jamaica
                     name: Jamaica
-                    parent_id: 1492a775-c51f-45a7-a18e-54bb66e83ab6
+                    parent_id: baff2f81-9396-463a-a076-fd8ead561b84
               schema:
                 "$ref": "#/components/schemas/subgeographic_geojson"
         '422':
@@ -1387,6 +1545,8 @@ components:
             primary_office_country:
               "$ref": "#/components/schemas/response_relation"
             subgeographics:
+              "$ref": "#/components/schemas/response_relations"
+            subgeographic_ancestors:
               "$ref": "#/components/schemas/response_relations"
       required:
       - id


### PR DESCRIPTION
Adding `geographics`, `subgeographics` and all enum filters (`areas`, `demographics`, etc.) to Funder API endpoint.

I am adding `closure_tree` gem which helps me to keep hierarchic structure of recursive table (Subgeographics) so it is simple to filter and preload data based on it.

https://vizzuality.atlassian.net/browse/FORA-178
https://vizzuality.atlassian.net/browse/FORA-179