### PR TITLE
fix: Support plural enum filters for singular attributes

### DIFF
--- a/.github/workflows/backend_ci_cd.yml
+++ b/.github/workflows/backend_ci_cd.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install PostgreSQL client
         run: |
           sudo apt update
-          sudo bash -c "echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main >> /etc/apt/sources.list.d/pgdg.list"
+          sudo bash -c "echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg 14 >> /etc/apt/sources.list.d/pgdg.list"
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
           sudo apt-get -yqq install libpq-dev postgresql-client-14

--- a/backend/app/controllers/api/v1/funders_controller.rb
+++ b/backend/app/controllers/api/v1/funders_controller.rb
@@ -5,7 +5,7 @@ module API
 
       load_and_authorize_resource
 
-      ENUM_FILTERS = %i[areas demographics funder_types capital_types funder_legal_status]
+      ENUM_FILTERS = %i[areas demographics funder_types capital_types funder_legal_statuses]
       SORTING_COLUMNS = %i[name projects_count]
 
       def index

--- a/backend/app/services/api/enum_filter.rb
+++ b/backend/app/services/api/enum_filter.rb
@@ -21,7 +21,7 @@ module API
 
     def pluralize_keys_in(hash)
       hash.each_with_object({}) do |(key, value), res|
-        res[key.to_s] = value
+        res[key.to_s.singularize] = value
         res[key.to_s.pluralize] = value
       end
     end

--- a/backend/spec/fixtures/snapshots/api/v1/funders.json
+++ b/backend/spec/fixtures/snapshots/api/v1/funders.json
@@ -15,7 +15,7 @@
         "primary_contact_role": "intermediary",
         "website": "http://hilpert.biz/drusilla",
         "date_joined_fora": "2022-02-11T00:00:00.000Z",
-        "funder_type": "private_foundation",
+        "funder_type": "accelerator",
         "funder_type_other": "Dolores fugiat nesciunt accusantium.",
         "capital_acceptances": [
           "donations_accepted",
@@ -105,7 +105,7 @@
         "primary_contact_role": "funder",
         "website": "http://bartoletti.com/jeremiah_cronin",
         "date_joined_fora": "2022-03-29T00:00:00.000Z",
-        "funder_type": "loan_fund",
+        "funder_type": "advisory",
         "funder_type_other": "Placeat commodi libero et.",
         "capital_acceptances": [
           "advises_and_manages_capital",
@@ -185,7 +185,7 @@
         "primary_contact_role": "regrantor",
         "website": "http://kutch-spencer.com/moises",
         "date_joined_fora": "2021-11-18T00:00:00.000Z",
-        "funder_type": "funder_collaborative_or_network",
+        "funder_type": "advisory",
         "funder_type_other": "Enim repellat pariatur est.",
         "capital_acceptances": [
           "other",
@@ -265,7 +265,7 @@
         "primary_contact_role": "intermediary",
         "website": "http://hane.com/jules",
         "date_joined_fora": "2022-03-13T00:00:00.000Z",
-        "funder_type": "private_foundation",
+        "funder_type": "advisory",
         "funder_type_other": "Et quaerat omnis veniam.",
         "capital_acceptances": [
           "donations_accepted",

--- a/backend/spec/requests/api/v1/funders_spec.rb
+++ b/backend/spec/requests/api/v1/funders_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "API V1 Funders", type: :request do
       parameter name: "filter[demographics]", in: :query, type: :string, enum: Demographic::TYPES, description: "Filter results only for specified demographics. Use comma to separate multiple fields", required: false
       parameter name: "filter[funder_types]", in: :query, type: :string, enum: FunderType::TYPES, description: "Filter results only for specified funder types. Use comma to separate multiple fields", required: false
       parameter name: "filter[capital_types]", in: :query, type: :string, enum: CapitalType::TYPES, description: "Filter results only for specified capital types. Use comma to separate multiple fields", required: false
-      parameter name: "filter[funder_legal_status]", in: :query, type: :string, enum: FunderLegalStatus::TYPES, description: "Filter results only for specified funder legal status", required: false
+      parameter name: "filter[funder_legal_statuses]", in: :query, type: :string, enum: FunderLegalStatus::TYPES, description: "Filter results only for specified funder legal status. Use comma to separate multiple fields", required: false
       parameter name: "filter[full_text]", in: :query, type: :string, description: "Filter records by provided text", required: false
       parameter name: "page[number]", in: :query, type: :integer, description: "Page number. Default: 1", required: false
       parameter name: "page[size]", in: :query, type: :integer, description: "Per page items. Default: 10", required: false
@@ -24,8 +24,8 @@ RSpec.describe "API V1 Funders", type: :request do
 
       let(:country) { create :subgeographic, geographic: :countries }
       let!(:national) { create :subgeographic, geographic: :national, parent: country }
-      let!(:funders) { create_list :funder, 3, areas: ["equity_and_justice"] }
-      let!(:funder) { create :funder, subgeographics: [national], areas: ["food_sovereignty"] }
+      let!(:funders) { create_list :funder, 3, areas: ["equity_and_justice"], funder_type: "advisory" }
+      let!(:funder) { create :funder, subgeographics: [national], areas: ["food_sovereignty"], funder_type: "accelerator" }
 
       response "200", :success do
         schema type: :object, properties: {
@@ -89,10 +89,20 @@ RSpec.describe "API V1 Funders", type: :request do
         end
 
         context "when filtered for specified enums" do
-          let("filter[areas]") { "food_sovereignty" }
+          context "when used for array enums" do
+            let("filter[areas]") { "food_sovereignty" }
 
-          it "returns only funders at correct areas" do
-            expect(response_json["data"].pluck("id")).to eq([funder.id])
+            it "returns only funders at correct areas" do
+              expect(response_json["data"].pluck("id")).to eq([funder.id])
+            end
+          end
+
+          context "when used for string enums" do
+            let("filter[funder_types]") { "accelerator" }
+
+            it "returns only funders of correct funder type" do
+              expect(response_json["data"].pluck("id")).to eq([funder.id])
+            end
           end
         end
 

--- a/backend/spec/services/api/enum_filter_spec.rb
+++ b/backend/spec/services/api/enum_filter_spec.rb
@@ -4,26 +4,46 @@ RSpec.describe API::EnumFilter do
   subject { described_class.new query, filters }
 
   describe "#call" do
-    let!(:correct_funder) do
-      create :funder, areas: %w[equity_and_justice food_sovereignty], demographics: %w[black_or_african_american]
-    end
-    let!(:different_areas_funder) do
-      create :funder, areas: %w[climate_change], demographics: %w[black_or_african_american]
-    end
-    let!(:different_demographics_funder) do
-      create :funder, areas: %w[food_sovereignty], demographics: %w[women]
-    end
-    let!(:ignored_funder) do
-      create :funder, areas: %w[equity_and_justice food_sovereignty], demographics: %w[black_or_african_american]
+    context "when using multiple filters on string attributes" do
+      let!(:correct_funder) do
+        create :funder, funder_type: "accelerator", funder_legal_status: "for_profit"
+      end
+      let!(:different_funder_type_funder) do
+        create :funder, funder_type: "advisory", funder_legal_status: "for_profit"
+      end
+      let!(:different_funder_legal_status_funder) do
+        create :funder, funder_type: "accelerator", funder_legal_status: "government_organization"
+      end
+      let(:query) { Funder.all }
+      let(:filters) { {funder_types: "accelerator", funder_legal_statuses: "for_profit"} }
+
+      it "returns correct funder" do
+        expect(subject.call).to eq([correct_funder])
+      end
     end
 
-    let(:query) do
-      Funder.where id: [correct_funder.id, different_areas_funder.id, different_demographics_funder.id]
-    end
-    let(:filters) { {areas: "food_sovereignty,equity_and_justice", demographic: "black_or_african_american"} }
+    context "when using multiple filters on array attributes" do
+      let!(:correct_funder) do
+        create :funder, areas: %w[equity_and_justice food_sovereignty], demographics: %w[black_or_african_american]
+      end
+      let!(:different_areas_funder) do
+        create :funder, areas: %w[climate_change], demographics: %w[black_or_african_american]
+      end
+      let!(:different_demographics_funder) do
+        create :funder, areas: %w[food_sovereignty], demographics: %w[women]
+      end
+      let!(:ignored_funder) do
+        create :funder, areas: %w[equity_and_justice food_sovereignty], demographics: %w[black_or_african_american]
+      end
 
-    it "returns correct funder" do
-      expect(subject.call).to eq([correct_funder])
+      let(:query) do
+        Funder.where id: [correct_funder.id, different_areas_funder.id, different_demographics_funder.id]
+      end
+      let(:filters) { {areas: "food_sovereignty,equity_and_justice", demographic: "black_or_african_american"} }
+
+      it "returns correct funder" do
+        expect(subject.call).to eq([correct_funder])
+      end
     end
   end
 end

--- a/backend/spec/services/api/sorting_spec.rb
+++ b/backend/spec/services/api/sorting_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe API::Sorting do
   subject { described_class.new query, sorting, columns }
 
   describe "#call" do
-    let!(:funder_1) { create :funder, name: "BBBB", description: "BBBB" }
-    let!(:funder_2) { create :funder, name: "AAAA", description: "AAAA" }
+    let!(:funder_1) { create :funder, name: "BBBB", description: "BBBB", created_at: 1.day.ago, updated_at: 1.day.ago }
+    let!(:funder_2) { create :funder, name: "AAAA", description: "AAAA", created_at: Time.current, updated_at: Time.current }
     let(:query) { Funder.all }
     let(:columns) { %i[name] }
 

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -645,7 +645,7 @@ paths:
         required: false
         schema:
           type: string
-      - name: filter[funder_legal_status]
+      - name: filter[funder_legal_statuses]
         in: query
         enum:
         - for_profit
@@ -654,7 +654,8 @@ paths:
         - non_profit
         - research_institution
         - other
-        description: Filter results only for specified funder legal status
+        description: Filter results only for specified funder legal status. Use comma
+          to separate multiple fields
         required: false
         schema:
           type: string
@@ -719,7 +720,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 3bcfb15e-7722-4987-b017-7f101ea65b6a
+                - id: d62c1a45-d808-4655-b921-3ed663876a32
                   type: funder
                   attributes:
                     name: Elbert Denesik
@@ -733,8 +734,8 @@ paths:
                     primary_contact_location: 851 Drusilla Lodge, Port Randy, VT 43075
                     primary_contact_role: intermediary
                     website: http://hilpert.biz/drusilla
-                    date_joined_fora: '2022-02-17T00:00:00.000Z'
-                    funder_type: private_foundation
+                    date_joined_fora: '2022-02-18T00:00:00.000Z'
+                    funder_type: accelerator
                     funder_type_other: Dolores fugiat nesciunt accusantium.
                     capital_acceptances:
                     - donations_accepted
@@ -765,29 +766,29 @@ paths:
                     demographics_other: Dolores fugiat nesciunt accusantium.
                     contact_email: lauren@ruecker.io
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WkRWak9URm1OeTFqTWpaa0xUUTBOamN0T0dFek5TMHhaRFJoT1RaallXRmtNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0e7a3fa59a57cb7b78196f5b99fe0048b76172d0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WkRWak9URm1OeTFqTWpaa0xUUTBOamN0T0dFek5TMHhaRFJoT1RaallXRmtNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0e7a3fa59a57cb7b78196f5b99fe0048b76172d0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WkRWak9URm1OeTFqTWpaa0xUUTBOamN0T0dFek5TMHhaRFJoT1RaallXRmtNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0e7a3fa59a57cb7b78196f5b99fe0048b76172d0/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5T0dKbE56UTNPQzAyTkRjMkxUUTVaV1F0T0dZMFl5MDJaalZqTldVeE9UQTNNV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0ed264e5eaac5b78cff95b71a1683866ac4796db/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5T0dKbE56UTNPQzAyTkRjMkxUUTVaV1F0T0dZMFl5MDJaalZqTldVeE9UQTNNV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0ed264e5eaac5b78cff95b71a1683866ac4796db/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5T0dKbE56UTNPQzAyTkRjMkxUUTVaV1F0T0dZMFl5MDJaalZqTldVeE9UQTNNV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0ed264e5eaac5b78cff95b71a1683866ac4796db/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 708e801a-7510-46be-a0ac-418f5b7bd4b4
+                        id: 2e7ec70a-3054-4a89-bb7d-2e4a73122076
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: c3ccf8ac-89de-4038-95f6-ce0b7566250b
+                        id: b495eae1-c6eb-4618-b42d-72d03bd1314c
                         type: subgeographic
                     subgeographics:
                       data:
-                      - id: cbe0ae74-e749-45c3-aebd-17599e99d124
+                      - id: 89116daf-d4be-4c2f-8c41-d6fd36103d26
                         type: subgeographic
                     subgeographic_ancestors:
                       data:
-                      - id: cbe0ae74-e749-45c3-aebd-17599e99d124
+                      - id: 89116daf-d4be-4c2f-8c41-d6fd36103d26
                         type: subgeographic
-                      - id: 9bf2bf6a-3d3d-405f-92b2-64e643ccbec6
+                      - id: 56ed2510-07eb-4803-be9a-2e907d971a6d
                         type: subgeographic
-                - id: 129f1b2b-fb36-4a97-922f-e6952726fb99
+                - id: 43a49165-8fe9-4a88-899c-da9875b0ea60
                   type: funder
                   attributes:
                     name: Msgr. Genaro Cronin
@@ -802,8 +803,8 @@ paths:
                       44573
                     primary_contact_role: funder
                     website: http://bartoletti.com/jeremiah_cronin
-                    date_joined_fora: '2022-04-04T00:00:00.000Z'
-                    funder_type: loan_fund
+                    date_joined_fora: '2022-04-05T00:00:00.000Z'
+                    funder_type: advisory
                     funder_type_other: Placeat commodi libero et.
                     capital_acceptances:
                     - advises_and_manages_capital
@@ -834,23 +835,23 @@ paths:
                     demographics_other: Placeat commodi libero et.
                     contact_email: desmond_herzog@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWVRrNE1EZ3paaTB4WmpRd0xUUTROV0V0WW1VeVl5MDBaRFF5TXpsak0yTXdObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f690fd7a23a95e44e280aabc9ed82d0b7f088e1e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWVRrNE1EZ3paaTB4WmpRd0xUUTROV0V0WW1VeVl5MDBaRFF5TXpsak0yTXdObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f690fd7a23a95e44e280aabc9ed82d0b7f088e1e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxWVRrNE1EZ3paaTB4WmpRd0xUUTROV0V0WW1VeVl5MDBaRFF5TXpsak0yTXdObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f690fd7a23a95e44e280aabc9ed82d0b7f088e1e/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TkRVeE1tRmpOQzA1T0RnMExUUXlZV1l0T0dGaU1pMDFaamcyT0dRNU9UaGxPVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--300091d977f6b39ab03573a12e1be8e7e7953c8c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TkRVeE1tRmpOQzA1T0RnMExUUXlZV1l0T0dGaU1pMDFaamcyT0dRNU9UaGxPVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--300091d977f6b39ab03573a12e1be8e7e7953c8c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TkRVeE1tRmpOQzA1T0RnMExUUXlZV1l0T0dGaU1pMDFaamcyT0dRNU9UaGxPVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--300091d977f6b39ab03573a12e1be8e7e7953c8c/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 12e8e2a8-14c9-4ac2-9b15-45da2b84181d
+                        id: 8e2e2fb8-4cc1-4009-b965-699a33eb2d9f
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: d011cf43-b42e-4190-a51f-46830a8a1e69
+                        id: da4a7da5-b001-4ea5-8f7e-73278cf5c2ed
                         type: subgeographic
                     subgeographics:
                       data: []
                     subgeographic_ancestors:
                       data: []
-                - id: 899bf4cc-841b-4099-8806-6d47b9ff036f
+                - id: 6ac0bf96-85e6-400d-93e0-06ec8e2f5a4a
                   type: funder
                   attributes:
                     name: Otha Kemmer
@@ -865,8 +866,8 @@ paths:
                       WY 06997-6910
                     primary_contact_role: regrantor
                     website: http://kutch-spencer.com/moises
-                    date_joined_fora: '2021-11-24T00:00:00.000Z'
-                    funder_type: funder_collaborative_or_network
+                    date_joined_fora: '2021-11-25T00:00:00.000Z'
+                    funder_type: advisory
                     funder_type_other: Enim repellat pariatur est.
                     capital_acceptances:
                     - other
@@ -897,23 +898,23 @@ paths:
                     demographics_other: Enim repellat pariatur est.
                     contact_email: dawna.block@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdFd05XUXhOUzFrWVRoaUxUUmlNR0V0T1RVeE1pMW1OakptTnpKaU5EWmtORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b14e0d7274bdc7513a04c77beb4612adf6819335/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdFd05XUXhOUzFrWVRoaUxUUmlNR0V0T1RVeE1pMW1OakptTnpKaU5EWmtORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b14e0d7274bdc7513a04c77beb4612adf6819335/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtTkdFd05XUXhOUzFrWVRoaUxUUmlNR0V0T1RVeE1pMW1OakptTnpKaU5EWmtORFlHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b14e0d7274bdc7513a04c77beb4612adf6819335/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyT1dJMVpqRmlNQzAyWXpRMExUUTVNRGd0WVRKbE15MWlNMkpqTjJGaFlUTmlNMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9ecf35c1474756ed7ac435cc3ce1ccc686b4e6be/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyT1dJMVpqRmlNQzAyWXpRMExUUTVNRGd0WVRKbE15MWlNMkpqTjJGaFlUTmlNMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9ecf35c1474756ed7ac435cc3ce1ccc686b4e6be/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyT1dJMVpqRmlNQzAyWXpRMExUUTVNRGd0WVRKbE15MWlNMkpqTjJGaFlUTmlNMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9ecf35c1474756ed7ac435cc3ce1ccc686b4e6be/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: b68efc52-6633-47c2-a1c4-f72e5caff180
+                        id: bf67ce84-2208-4d8f-b352-57362bb46fec
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: 9db6c5f6-c212-4531-9d85-467d9e9033cb
+                        id: 04f10c31-efd1-499f-bb49-bc5efb657df8
                         type: subgeographic
                     subgeographics:
                       data: []
                     subgeographic_ancestors:
                       data: []
-                - id: 33e53760-ddaa-479d-861c-b2510c8c8ad2
+                - id: 525ac5c9-7c0e-46e8-baec-5657ef7f8b5b
                   type: funder
                   attributes:
                     name: Raymon Wisoky
@@ -928,8 +929,8 @@ paths:
                       60478-1622
                     primary_contact_role: intermediary
                     website: http://hane.com/jules
-                    date_joined_fora: '2022-03-19T00:00:00.000Z'
-                    funder_type: private_foundation
+                    date_joined_fora: '2022-03-20T00:00:00.000Z'
+                    funder_type: advisory
                     funder_type_other: Et quaerat omnis veniam.
                     capital_acceptances:
                     - donations_accepted
@@ -960,17 +961,17 @@ paths:
                     demographics_other: Et quaerat omnis veniam.
                     contact_email: jules_keeling@grimes-stokes.co
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTmpoaU5XTTVPQzAwTXpSaUxUUTNZVFF0T0RZM05TMDBOREEwT0RFME5HRmhOekVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1746e79f6b13882214c556c920aefc631087a738/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTmpoaU5XTTVPQzAwTXpSaUxUUTNZVFF0T0RZM05TMDBOREEwT0RFME5HRmhOekVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1746e79f6b13882214c556c920aefc631087a738/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTmpoaU5XTTVPQzAwTXpSaUxUUTNZVFF0T0RZM05TMDBOREEwT0RFME5HRmhOekVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1746e79f6b13882214c556c920aefc631087a738/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWVRFelpUaGxNUzB3WmpWbExUUm1Namt0T0dReU55MDRNVGs0TXpaaFlUbG1OelVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c203b32e8d3e711e0009dfaeb6a4e3a04208e7d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWVRFelpUaGxNUzB3WmpWbExUUm1Namt0T0dReU55MDRNVGs0TXpaaFlUbG1OelVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c203b32e8d3e711e0009dfaeb6a4e3a04208e7d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWVRFelpUaGxNUzB3WmpWbExUUm1Namt0T0dReU55MDRNVGs0TXpaaFlUbG1OelVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--6c203b32e8d3e711e0009dfaeb6a4e3a04208e7d/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 9b6d2da2-259d-45b4-b215-cf51e4544f6b
+                        id: 0714e35f-e263-4ad4-b6ea-e102f7774fcb
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: 806c874c-9c9e-44a8-a21a-686676cf2044
+                        id: 61465b73-ef96-484d-b444-79225dc7fd81
                         type: subgeographic
                     subgeographics:
                       data: []
@@ -1040,7 +1041,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: e0e10e35-95cc-4a22-a7ba-d39c0ae954ed
+                  id: 4362ba86-c05e-42d3-83c8-f30f8434dbc0
                   type: funder
                   attributes:
                     name: Otha Kemmer
@@ -1055,7 +1056,7 @@ paths:
                       WY 06997-6910
                     primary_contact_role: regrantor
                     website: http://kutch-spencer.com/moises
-                    date_joined_fora: '2021-11-24T00:00:00.000Z'
+                    date_joined_fora: '2021-11-25T00:00:00.000Z'
                     funder_type: funder_collaborative_or_network
                     funder_type_other: Enim repellat pariatur est.
                     capital_acceptances:
@@ -1088,27 +1089,27 @@ paths:
                     demographics_other: Enim repellat pariatur est.
                     contact_email: dawna.block@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTnpBNVltVTNZaTFqTmpNM0xUUmtabUl0T1dabFl5MW1NelF3WlRZeE1tTmhZemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b391141de8f3e1635620b481fbdd630136dfcdd6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTnpBNVltVTNZaTFqTmpNM0xUUmtabUl0T1dabFl5MW1NelF3WlRZeE1tTmhZemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b391141de8f3e1635620b481fbdd630136dfcdd6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyTnpBNVltVTNZaTFqTmpNM0xUUmtabUl0T1dabFl5MW1NelF3WlRZeE1tTmhZemtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b391141de8f3e1635620b481fbdd630136dfcdd6/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TmpOaU16WXpOUzAyTmpVMUxUUXlPVE10WVdFeE9TMHpOV0pqWXpVNE0yRTRaVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--522cbfe6ffcadce1a60744bad272861bef17e694/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TmpOaU16WXpOUzAyTmpVMUxUUXlPVE10WVdFeE9TMHpOV0pqWXpVNE0yRTRaVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--522cbfe6ffcadce1a60744bad272861bef17e694/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TmpOaU16WXpOUzAyTmpVMUxUUXlPVE10WVdFeE9TMHpOV0pqWXpVNE0yRTRaVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--522cbfe6ffcadce1a60744bad272861bef17e694/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: deac47ea-482d-4c18-b81f-8e3231c8680e
+                        id: 3df207a4-83d9-446f-ab2a-892304efc856
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: 2a280f69-6038-4b87-91af-ebd28f255929
+                        id: c88ec6af-c8d1-45c7-babb-94af5621902b
                         type: subgeographic
                     subgeographics:
                       data:
-                      - id: 9742a3c7-c81b-409b-b2a1-1be6a3d3e791
+                      - id: 767394a5-31a5-419a-b6f6-094af7be50a8
                         type: subgeographic
                     subgeographic_ancestors:
                       data:
-                      - id: 9742a3c7-c81b-409b-b2a1-1be6a3d3e791
+                      - id: ec24ff95-78cb-4726-abdd-0373e309db5c
                         type: subgeographic
-                      - id: 3935b001-272c-463b-9cf4-3782ee3eed2a
+                      - id: 767394a5-31a5-419a-b6f6-094af7be50a8
                         type: subgeographic
               schema:
                 type: object
@@ -1313,35 +1314,35 @@ paths:
             application/json:
               example:
                 data:
-                - id: 33ceee7b-f644-4bf1-ba3c-46d685b0c81d
+                - id: 0cde7263-552b-4b7f-a301-767e2d7ee368
                   type: subgeographic
                   attributes:
                     name: Canada
                     code: BWA
                     geographic: countries
                     abbreviation: C-BWA
-                    created_at: '2022-10-13T08:09:03.831Z'
-                    updated_at: '2022-10-13T08:09:03.831Z'
+                    created_at: '2022-10-14T09:29:05.873Z'
+                    updated_at: '2022-10-14T09:29:05.873Z'
                   relationships:
                     parent:
                       data:
                     subgeographics:
                       data:
-                      - id: bbd53e23-0da5-4c4c-a65e-5283607e698b
+                      - id: 98b584b4-3a0a-4b94-80d4-c8eec12c72af
                         type: subgeographic
-                - id: bbd53e23-0da5-4c4c-a65e-5283607e698b
+                - id: 98b584b4-3a0a-4b94-80d4-c8eec12c72af
                   type: subgeographic
                   attributes:
                     name: Papua New Guinea
                     code: NPL
                     geographic: regions
                     abbreviation: R-NPL
-                    created_at: '2022-10-13T08:09:03.846Z'
-                    updated_at: '2022-10-13T08:09:03.846Z'
+                    created_at: '2022-10-14T09:29:05.887Z'
+                    updated_at: '2022-10-14T09:29:05.887Z'
                   relationships:
                     parent:
                       data:
-                        id: 33ceee7b-f644-4bf1-ba3c-46d685b0c81d
+                        id: 0cde7263-552b-4b7f-a301-767e2d7ee368
                         type: subgeographic
                     subgeographics:
                       data: []
@@ -1387,11 +1388,11 @@ paths:
                       - - 0
                         - 0
                   properties:
-                    id: 1014e279-47cd-4e70-8f64-334428b0a6ee
+                    id: b78d40ff-1a8f-4c43-8ec4-faa4572f5ab6
                     code: NPL
                     name: Papua New Guinea
                     abbreviation: R-NPL
-                    parent_id: bd53f930-dbe9-4108-9d15-928550cb55c8
+                    parent_id: 9f05ff67-ddb4-4af7-bb81-d43adac22e36
                 - type: Feature
                   geometry:
                     type: Polygon
@@ -1407,11 +1408,11 @@ paths:
                       - - 0
                         - 0
                   properties:
-                    id: d2e4dc87-54d4-46b6-83e7-8a2de7971101
+                    id: 0e90264f-cf45-4f54-a9f1-11b0f37de032
                     code: IRL
                     name: Jamaica
                     abbreviation: R-IRL
-                    parent_id: bd53f930-dbe9-4108-9d15-928550cb55c8
+                    parent_id: 9f05ff67-ddb4-4af7-bb81-d43adac22e36
               schema:
                 "$ref": "#/components/schemas/subgeographic_geojson"
         '422':


### PR DESCRIPTION
Fix of small bug discovered by @mbarrenechea which caused that plural enum filters for singular db attributes were not working. Examples of such filters are:
 - `filter[funder_types]` (plural) --> attribute on Funder model is called `funder_type` (singular)
 - `filter[funder_legal_statuses]` (plural) --> attribute on Funder model is called `funder_legal_status` (singular)

For testing purposes, it should be enough to just test that these two filters work