### PR TITLE
Filters for Projects API

### DIFF
--- a/backend/app/controllers/api/v1/funders_controller.rb
+++ b/backend/app/controllers/api/v1/funders_controller.rb
@@ -14,7 +14,7 @@ module API
         @funders = @funders.search filter_params[:full_text] if filter_params[:full_text].present?
         @funders = API::EnumFilter.new(@funders, filter_params.to_h.slice(*ENUM_FILTERS)).call
         @funders = Funder.with_projects_count.where(id: @funders.pluck(:id))
-          .includes :primary_office_state, :primary_office_country, :subgeographics, :subgeographic_ancestors, logo_attachment: [:blob]
+          .includes :primary_office_state, :primary_office_country, :subgeographics, :subgeographic_ancestors, :investments, logo_attachment: [:blob]
         @funders = API::Sorting.new(@funders, sorting_params, SORTING_COLUMNS).call.order :created_at
         pagy_object, @funders = pagy @funders, page: current_page, items: per_page unless params[:disable_pagination].to_s == "true"
         render json: FunderSerializer.new(

--- a/backend/app/controllers/api/v1/projects_controller.rb
+++ b/backend/app/controllers/api/v1/projects_controller.rb
@@ -10,6 +10,7 @@ module API
       def index
         @projects = @projects.for_subgeographics filter_params[:subgeographics].split(",") if filter_params[:subgeographics].present?
         @projects = @projects.for_geographics filter_params[:geographic] if filter_params[:geographic].present?
+        @projects = @projects.search filter_params[:full_text] if filter_params[:full_text].present?
         @projects = API::EnumFilter.new(
           @projects.joins(:recipient).left_joins(:investments),
           filter_params.to_h.slice(*ENUM_FILTERS),
@@ -40,7 +41,7 @@ module API
       private
 
       def filter_params
-        params.fetch(:filter, {}).permit :geographic, :subgeographics, *ENUM_FILTERS
+        params.fetch(:filter, {}).permit :geographic, :subgeographics, :full_text, *ENUM_FILTERS
       end
     end
   end

--- a/backend/app/controllers/api/v1/projects_controller.rb
+++ b/backend/app/controllers/api/v1/projects_controller.rb
@@ -18,7 +18,7 @@ module API
           extra_models: [Recipient, Investment]
         ).call
         @projects = Project.with_funders_count.where(id: @projects.pluck(:id))
-          .includes recipient: [:state, :country, :subgeographics, :subgeographic_ancestors, logo_attachment: [:blob]]
+          .includes recipient: [:state, :country, :subgeographics, :subgeographic_ancestors, :investments, logo_attachment: [:blob]]
         @projects = API::Sorting.new(@projects, sorting_params, SORTING_COLUMNS).call.order :created_at
         pagy_object, @projects = pagy @projects, page: current_page, items: per_page unless params[:disable_pagination].to_s == "true"
         render json: ProjectSerializer.new(

--- a/backend/app/controllers/api/v1/projects_controller.rb
+++ b/backend/app/controllers/api/v1/projects_controller.rb
@@ -3,8 +3,18 @@ module API
     class ProjectsController < BaseController
       load_and_authorize_resource
 
+      ENUM_FILTERS = %i[areas demographics recipient_legal_statuses]
+
       def index
-        @projects = @projects.includes recipient: [:state, :country, :subgeographics, :subgeographic_ancestors, logo_attachment: [:blob]]
+        @projects = @projects.for_subgeographics filter_params[:subgeographics].split(",") if filter_params[:subgeographics].present?
+        @projects = @projects.for_geographics filter_params[:geographic] if filter_params[:geographic].present?
+        @projects = API::EnumFilter.new(
+          @projects.joins(:recipient).left_joins(:investments),
+          filter_params.to_h.slice(*ENUM_FILTERS),
+          extra_models: [Recipient, Investment]
+        ).call
+        @projects = Project.where(id: @projects.pluck(:id))
+          .includes recipient: [:state, :country, :subgeographics, :subgeographic_ancestors, logo_attachment: [:blob]]
         render json: ProjectSerializer.new(
           @projects,
           include: included_relationships,
@@ -20,6 +30,12 @@ module API
           fields: sparse_fieldset,
           params: {current_user: current_user, current_ability: current_ability}
         ).serializable_hash
+      end
+
+      private
+
+      def filter_params
+        params.fetch(:filter, {}).permit :geographic, :subgeographics, *ENUM_FILTERS
       end
     end
   end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -30,6 +30,10 @@ class Project < ApplicationRecord
 
   scope :for_subgeographics, ->(abbreviations) { joins(recipient: :subgeographic_ancestors).where(subgeographics: {abbreviation: abbreviations}) }
   scope :for_geographics, ->(geographics) { joins(recipient: :subgeographic_ancestors).where(subgeographics: {geographic: geographics}) }
+  scope :with_funders_count, -> {
+    funders_count = Investment.where("investments.project_id = projects.id").select("COUNT(DISTINCT investments.funder_id)").to_sql
+    select "projects.*, (#{funders_count}) AS funders_count"
+  }
 
   def recipient_name
     recipient.name

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -24,6 +24,9 @@ class Project < ApplicationRecord
     :logo,
     to: :recipient
 
+  scope :for_subgeographics, ->(abbreviations) { joins(recipient: :subgeographic_ancestors).where(subgeographics: {abbreviation: abbreviations}) }
+  scope :for_geographics, ->(geographics) { joins(recipient: :subgeographic_ancestors).where(subgeographics: {geographic: geographics}) }
+
   def recipient_name
     recipient.name
   end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -1,8 +1,12 @@
 class Project < ApplicationRecord
+  include PgSearch::Model
+
   belongs_to :recipient
 
   has_many :investments, dependent: :destroy
   has_many :funders, -> { distinct }, through: :investments
+
+  pg_search_scope :search, against: [:name, :description]
 
   validates_uniqueness_of :name, case_sensitive: false, allow_blank: true
 

--- a/backend/app/serializers/api/v1/funder_serializer.rb
+++ b/backend/app/serializers/api/v1/funder_serializer.rb
@@ -39,6 +39,7 @@ module API
 
       has_many_restricted :subgeographics
       has_many_restricted :subgeographic_ancestors, serializer: :subgeographic
+      has_many_restricted :investments
 
       attribute :contact_email do |object, _params|
         next object.secondary_email_which_can_be_shared unless object.show_primary_email?

--- a/backend/app/serializers/api/v1/investment_serializer.rb
+++ b/backend/app/serializers/api/v1/investment_serializer.rb
@@ -1,0 +1,20 @@
+module API
+  module V1
+    class InvestmentSerializer < BaseSerializer
+      attributes :amount,
+        :year_invested,
+        :initial_funded_year,
+        :funding_type,
+        :funding_type_other,
+        :capital_types,
+        :areas,
+        :areas_other,
+        :grant_duration,
+        :grant_duration_other,
+        :number_of_grant_years
+
+      belongs_to_restricted :funder
+      belongs_to_restricted :project
+    end
+  end
+end

--- a/backend/app/serializers/api/v1/project_serializer.rb
+++ b/backend/app/serializers/api/v1/project_serializer.rb
@@ -19,6 +19,7 @@ module API
 
       has_many_restricted :subgeographics
       has_many_restricted :subgeographic_ancestors, serializer: :subgeographic
+      has_many_restricted :investments
 
       attribute :logo do |object|
         image_links_for object.logo

--- a/backend/app/services/api/enum_filter.rb
+++ b/backend/app/services/api/enum_filter.rb
@@ -1,10 +1,11 @@
 module API
   class EnumFilter
-    attr_accessor :query, :filters
+    attr_accessor :query, :filters, :extra_models
 
-    def initialize(query, filters)
+    def initialize(query, filters, extra_models: [])
       @query = query
       @filters = filters
+      @extra_models = extra_models
     end
 
     def call
@@ -27,7 +28,7 @@ module API
     end
 
     def column_names
-      @column_names ||= query.klass.column_names
+      @column_names ||= query.klass.column_names + extra_models.map { |m| m.column_names }.flatten
     end
   end
 end

--- a/backend/spec/fixtures/snapshots/api/v1/funders.json
+++ b/backend/spec/fixtures/snapshots/api/v1/funders.json
@@ -87,6 +87,11 @@
               "type": "subgeographic"
             }
           ]
+        },
+        "investments": {
+          "data": [
+
+          ]
         }
       }
     },
@@ -164,6 +169,11 @@
           ]
         },
         "subgeographic_ancestors": {
+          "data": [
+
+          ]
+        },
+        "investments": {
           "data": [
 
           ]
@@ -247,6 +257,11 @@
           "data": [
 
           ]
+        },
+        "investments": {
+          "data": [
+
+          ]
         }
       }
     },
@@ -324,6 +339,11 @@
           ]
         },
         "subgeographic_ancestors": {
+          "data": [
+
+          ]
+        },
+        "investments": {
           "data": [
 
           ]

--- a/backend/spec/fixtures/snapshots/api/v1/get-funder.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-funder.json
@@ -87,6 +87,11 @@
             "type": "subgeographic"
           }
         ]
+      },
+      "investments": {
+        "data": [
+
+        ]
       }
     }
   }

--- a/backend/spec/fixtures/snapshots/api/v1/get-project.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "b050277a-3669-4176-8f7b-23d144ddfb4d",
+    "id": "49b4e5b3-addd-426e-b954-db38c3272e21",
     "type": "project",
     "attributes": {
       "name": "Otha Kemmer",
@@ -20,28 +20,28 @@
       "recipient_legal_status": "foundation",
       "recipient_legal_status_other": "Enim repellat pariatur est.",
       "logo": {
-        "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WlRreE5XRTNaQzFqWlRFM0xUUTVaalF0T1dRNU1TMHdZV1ZpWm1Ka09HWXlaR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0872efb880483a6af438a788320f8f105476663f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-        "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WlRreE5XRTNaQzFqWlRFM0xUUTVaalF0T1dRNU1TMHdZV1ZpWm1Ka09HWXlaR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0872efb880483a6af438a788320f8f105476663f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-        "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt5WlRreE5XRTNaQzFqWlRFM0xUUTVaalF0T1dRNU1TMHdZV1ZpWm1Ka09HWXlaR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--0872efb880483a6af438a788320f8f105476663f/picture.jpg"
+        "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWkRBM1lUTTVOUzAxWW1VMExUUmpOalV0T1dVNE5DMWpZemd4T0dZME1qa3dPR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--98ccfd01eae39d3cb34003cd9b17acb05cd5d0e5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+        "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWkRBM1lUTTVOUzAxWW1VMExUUmpOalV0T1dVNE5DMWpZemd4T0dZME1qa3dPR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--98ccfd01eae39d3cb34003cd9b17acb05cd5d0e5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+        "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpWkRBM1lUTTVOUzAxWW1VMExUUmpOalV0T1dVNE5DMWpZemd4T0dZME1qa3dPR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--98ccfd01eae39d3cb34003cd9b17acb05cd5d0e5/picture.jpg"
       }
     },
     "relationships": {
       "state": {
         "data": {
-          "id": "6ef7a886-77ff-4586-9602-3b4e4ba9663b",
+          "id": "2a7ea8a6-a10a-4184-aae1-f329740cb1d1",
           "type": "subgeographic"
         }
       },
       "country": {
         "data": {
-          "id": "ebc3aaca-0146-483c-a9ec-e4def4bc8d3e",
+          "id": "35b8c4cf-b5ba-4f62-8144-c5d52d62dcdc",
           "type": "subgeographic"
         }
       },
       "subgeographics": {
         "data": [
           {
-            "id": "8049b8c9-8ae7-41da-a8f1-f626a7586fa1",
+            "id": "a0b9c232-a5ab-44a5-8a59-9717d41b66c8",
             "type": "subgeographic"
           }
         ]
@@ -49,11 +49,11 @@
       "subgeographic_ancestors": {
         "data": [
           {
-            "id": "8049b8c9-8ae7-41da-a8f1-f626a7586fa1",
+            "id": "a0b9c232-a5ab-44a5-8a59-9717d41b66c8",
             "type": "subgeographic"
           },
           {
-            "id": "ac1fc99e-ca92-4e09-8475-73bd6bb81e13",
+            "id": "6f2bbd1c-4bfe-44cc-b846-c8bf3d2612fb",
             "type": "subgeographic"
           }
         ]

--- a/backend/spec/fixtures/snapshots/api/v1/get-project.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get-project.json
@@ -57,6 +57,11 @@
             "type": "subgeographic"
           }
         ]
+      },
+      "investments": {
+        "data": [
+
+        ]
       }
     }
   }

--- a/backend/spec/fixtures/snapshots/api/v1/projects-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects-include-relationships.json
@@ -4,12 +4,15 @@
       "id": "c0411e15-9bcc-4a14-96fa-b261de63881f",
       "type": "project",
       "attributes": {
-        "name": "Otha Kemmer"
+        "name": "Elbert Denesik"
       },
       "relationships": {
         "subgeographics": {
           "data": [
-
+            {
+              "id": "97967246-5610-412d-bd9e-618457274e6d",
+              "type": "subgeographic"
+            }
           ]
         }
       }
@@ -32,7 +35,7 @@
       "id": "921482cd-2b78-4fb0-adde-9d9f25e324b5",
       "type": "project",
       "attributes": {
-        "name": "Raymon Wisoky"
+        "name": "Otha Kemmer"
       },
       "relationships": {
         "subgeographics": {
@@ -46,15 +49,12 @@
       "id": "3fd5c235-6ed1-43df-b806-d443e2c6702a",
       "type": "project",
       "attributes": {
-        "name": "Elbert Denesik"
+        "name": "Raymon Wisoky"
       },
       "relationships": {
         "subgeographics": {
           "data": [
-            {
-              "id": "208e4725-7028-4866-82c6-8f15f7aa836f",
-              "type": "subgeographic"
-            }
+
           ]
         }
       }

--- a/backend/spec/fixtures/snapshots/api/v1/projects-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects-include-relationships.json
@@ -14,6 +14,14 @@
               "type": "subgeographic"
             }
           ]
+        },
+        "investments": {
+          "data": [
+            {
+              "id": "c8ff1d98-f5ff-4d84-a254-186453141979",
+              "type": "investment"
+            }
+          ]
         }
       }
     },
@@ -25,6 +33,11 @@
       },
       "relationships": {
         "subgeographics": {
+          "data": [
+
+          ]
+        },
+        "investments": {
           "data": [
 
           ]
@@ -42,6 +55,14 @@
           "data": [
 
           ]
+        },
+        "investments": {
+          "data": [
+            {
+              "id": "0664da55-c1d2-4631-8987-67b9ff5fd05d",
+              "type": "investment"
+            }
+          ]
         }
       }
     },
@@ -53,6 +74,11 @@
       },
       "relationships": {
         "subgeographics": {
+          "data": [
+
+          ]
+        },
+        "investments": {
           "data": [
 
           ]
@@ -83,6 +109,78 @@
           "data": [
 
           ]
+        }
+      }
+    },
+    {
+      "id": "c8ff1d98-f5ff-4d84-a254-186453141979",
+      "type": "investment",
+      "attributes": {
+        "amount": "98.63",
+        "year_invested": 2021,
+        "initial_funded_year": 2021,
+        "funding_type": "general_operating_support",
+        "funding_type_other": "Placeat commodi libero et.",
+        "capital_types": [
+          "grants",
+          "forgivable_loans"
+        ],
+        "areas": [
+          "food_sovereignty"
+        ],
+        "areas_other": "Placeat commodi libero et.",
+        "grant_duration": "one_year",
+        "grant_duration_other": "Placeat commodi libero et.",
+        "number_of_grant_years": 1
+      },
+      "relationships": {
+        "funder": {
+          "data": {
+            "id": "570de809-8023-41fb-bf24-dd57c450cc3a",
+            "type": "funder"
+          }
+        },
+        "project": {
+          "data": {
+            "id": "773237c0-2c69-4829-9a2a-0694fd4e70ba",
+            "type": "project"
+          }
+        }
+      }
+    },
+    {
+      "id": "0664da55-c1d2-4631-8987-67b9ff5fd05d",
+      "type": "investment",
+      "attributes": {
+        "amount": "68.96",
+        "year_invested": 2020,
+        "initial_funded_year": 2020,
+        "funding_type": "program_or_project_specific",
+        "funding_type_other": "Enim repellat pariatur est.",
+        "capital_types": [
+          "re_grants",
+          "pris"
+        ],
+        "areas": [
+          "equity_and_justice"
+        ],
+        "areas_other": "Enim repellat pariatur est.",
+        "grant_duration": "multi_year",
+        "grant_duration_other": "Enim repellat pariatur est.",
+        "number_of_grant_years": 4
+      },
+      "relationships": {
+        "funder": {
+          "data": {
+            "id": "fa1a7bef-4f26-4ba2-991f-3e7b69d551f5",
+            "type": "funder"
+          }
+        },
+        "project": {
+          "data": {
+            "id": "3b3b29d0-bcd1-4f8e-988c-61be5d96acd6",
+            "type": "project"
+          }
         }
       }
     }

--- a/backend/spec/fixtures/snapshots/api/v1/projects-include-relationships.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects-include-relationships.json
@@ -86,5 +86,18 @@
         }
       }
     }
-  ]
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 4,
+    "total": 4,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/projects?page%5Bsize%5D=10",
+    "self": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/projects-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects-sparse-fieldset.json
@@ -40,5 +40,18 @@
       "relationships": {
       }
     }
-  ]
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 4,
+    "total": 4,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/projects?page%5Bsize%5D=10",
+    "self": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/projects-sparse-fieldset.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects-sparse-fieldset.json
@@ -4,8 +4,8 @@
       "id": "63f2bbe6-cc4b-416c-a216-4506ead70560",
       "type": "project",
       "attributes": {
-        "name": "Otha Kemmer",
-        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo."
+        "name": "Elbert Denesik",
+        "description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia."
       },
       "relationships": {
       }
@@ -24,8 +24,8 @@
       "id": "fc8bdb79-4d60-4500-b404-be8130b295c1",
       "type": "project",
       "attributes": {
-        "name": "Raymon Wisoky",
-        "description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum."
+        "name": "Otha Kemmer",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo."
       },
       "relationships": {
       }
@@ -34,8 +34,8 @@
       "id": "2404467d-8685-4d1b-b8d1-5d9341797bab",
       "type": "project",
       "attributes": {
-        "name": "Elbert Denesik",
-        "description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia."
+        "name": "Raymon Wisoky",
+        "description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum."
       },
       "relationships": {
       }

--- a/backend/spec/fixtures/snapshots/api/v1/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects.json
@@ -58,6 +58,14 @@
               "type": "subgeographic"
             }
           ]
+        },
+        "investments": {
+          "data": [
+            {
+              "id": "f453a8ec-cc81-42e5-a500-1e9c6db26d78",
+              "type": "investment"
+            }
+          ]
         }
       }
     },
@@ -106,6 +114,11 @@
           ]
         },
         "subgeographic_ancestors": {
+          "data": [
+
+          ]
+        },
+        "investments": {
           "data": [
 
           ]
@@ -160,6 +173,14 @@
           "data": [
 
           ]
+        },
+        "investments": {
+          "data": [
+            {
+              "id": "f1a81dab-ad35-46ee-9af6-0cb5bb1b64f2",
+              "type": "investment"
+            }
+          ]
         }
       }
     },
@@ -208,6 +229,11 @@
           ]
         },
         "subgeographic_ancestors": {
+          "data": [
+
+          ]
+        },
+        "investments": {
           "data": [
 
           ]

--- a/backend/spec/fixtures/snapshots/api/v1/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "30135c92-4d67-4b85-8c08-018036b8a79d",
+      "id": "8ff3eaeb-4f98-46d3-8b20-17907adc4ea6",
       "type": "project",
       "attributes": {
         "name": "Otha Kemmer",
@@ -18,24 +18,24 @@
           "other"
         ],
         "demographics_other": "Enim repellat pariatur est.",
-        "recipient_legal_status": "foundation",
+        "recipient_legal_status": "for_profit",
         "recipient_legal_status_other": "Enim repellat pariatur est.",
         "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TVRFd01qbGhPQzFpWVdJeUxUUXhPVGN0WW1VM01DMWhPRE5sWXpNNU5tWTBObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b96597317baa849b34cd224c45079d23a740ee25/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TVRFd01qbGhPQzFpWVdJeUxUUXhPVGN0WW1VM01DMWhPRE5sWXpNNU5tWTBObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b96597317baa849b34cd224c45079d23a740ee25/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TVRFd01qbGhPQzFpWVdJeUxUUXhPVGN0WW1VM01DMWhPRE5sWXpNNU5tWTBObUVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--b96597317baa849b34cd224c45079d23a740ee25/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/picture.jpg"
         }
       },
       "relationships": {
         "state": {
           "data": {
-            "id": "c812a2f2-8bab-4b7a-bf74-00ca993e07b8",
+            "id": "eb94a7a7-15f1-4ab2-94d2-934521fa29bd",
             "type": "subgeographic"
           }
         },
         "country": {
           "data": {
-            "id": "6355fb03-12ed-4252-bafb-107f366122ec",
+            "id": "c562c45a-bc09-4d25-839c-3d27f72efc4f",
             "type": "subgeographic"
           }
         },
@@ -52,11 +52,113 @@
       }
     },
     {
-      "id": "148e5f2c-569e-436d-86f4-712f92e4a54b",
+      "id": "9199a4f4-1d63-46d2-8b0d-5e441645dc07",
       "type": "project",
       "attributes": {
         "name": "Msgr. Genaro Cronin",
         "description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "recipient_name": "Otha Kemmer",
+        "website": "http://kutch-spencer.com/moises",
+        "leadership_demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "leadership_demographics_other": "Enim repellat pariatur est.",
+        "demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "demographics_other": "Enim repellat pariatur est.",
+        "recipient_legal_status": "for_profit",
+        "recipient_legal_status_other": "Enim repellat pariatur est.",
+        "logo": {
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/picture.jpg"
+        }
+      },
+      "relationships": {
+        "state": {
+          "data": {
+            "id": "eb94a7a7-15f1-4ab2-94d2-934521fa29bd",
+            "type": "subgeographic"
+          }
+        },
+        "country": {
+          "data": {
+            "id": "c562c45a-bc09-4d25-839c-3d27f72efc4f",
+            "type": "subgeographic"
+          }
+        },
+        "subgeographics": {
+          "data": [
+
+          ]
+        },
+        "subgeographic_ancestors": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "7cb9f8d3-6ce1-4d26-a559-1cfeac3dab00",
+      "type": "project",
+      "attributes": {
+        "name": "Raymon Wisoky",
+        "description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
+        "recipient_name": "Otha Kemmer",
+        "website": "http://kutch-spencer.com/moises",
+        "leadership_demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "leadership_demographics_other": "Enim repellat pariatur est.",
+        "demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "demographics_other": "Enim repellat pariatur est.",
+        "recipient_legal_status": "for_profit",
+        "recipient_legal_status_other": "Enim repellat pariatur est.",
+        "logo": {
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/picture.jpg"
+        }
+      },
+      "relationships": {
+        "state": {
+          "data": {
+            "id": "eb94a7a7-15f1-4ab2-94d2-934521fa29bd",
+            "type": "subgeographic"
+          }
+        },
+        "country": {
+          "data": {
+            "id": "c562c45a-bc09-4d25-839c-3d27f72efc4f",
+            "type": "subgeographic"
+          }
+        },
+        "subgeographics": {
+          "data": [
+
+          ]
+        },
+        "subgeographic_ancestors": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "03a0736a-2066-4101-81b2-028766523386",
+      "type": "project",
+      "attributes": {
+        "name": "Elbert Denesik",
+        "description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
         "recipient_name": "Msgr. Genaro Cronin",
         "website": "http://bartoletti.com/jeremiah_cronin",
         "leadership_demographics": [
@@ -69,133 +171,31 @@
           "other"
         ],
         "demographics_other": "Placeat commodi libero et.",
-        "recipient_legal_status": "for_profit",
+        "recipient_legal_status": "foundation",
         "recipient_legal_status_other": "Placeat commodi libero et.",
         "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWVdVNFlUTTROUzB3WW1ZNExUUTJaR1F0WWpJd09DMDNaV0UzTldZek9HSmhOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9005c1c43df7c9f2573b832d7ecc9e64da62c50d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWVdVNFlUTTROUzB3WW1ZNExUUTJaR1F0WWpJd09DMDNaV0UzTldZek9HSmhOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9005c1c43df7c9f2573b832d7ecc9e64da62c50d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsyWVdVNFlUTTROUzB3WW1ZNExUUTJaR1F0WWpJd09DMDNaV0UzTldZek9HSmhOVFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9005c1c43df7c9f2573b832d7ecc9e64da62c50d/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RFd1ltTXlOQzAzTVdNeExUUmtNbU10T1dVM1ppMHdPVGN5T0dJMU5qSTNNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7f250ce1e6c30ebc522b08d0365aa6ad722bb877/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RFd1ltTXlOQzAzTVdNeExUUmtNbU10T1dVM1ppMHdPVGN5T0dJMU5qSTNNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7f250ce1e6c30ebc522b08d0365aa6ad722bb877/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RFd1ltTXlOQzAzTVdNeExUUmtNbU10T1dVM1ppMHdPVGN5T0dJMU5qSTNNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7f250ce1e6c30ebc522b08d0365aa6ad722bb877/picture.jpg"
         }
       },
       "relationships": {
         "state": {
           "data": {
-            "id": "ea3d8082-b42e-4719-a9e6-9f2c6822e2ba",
+            "id": "02c0d71b-b0be-471f-ac06-29e077f3535e",
             "type": "subgeographic"
           }
         },
         "country": {
           "data": {
-            "id": "5b9ce432-cbc4-4bde-95a2-394e8e946a2e",
-            "type": "subgeographic"
-          }
-        },
-        "subgeographics": {
-          "data": [
-
-          ]
-        },
-        "subgeographic_ancestors": {
-          "data": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "c1655c34-1c62-4127-8c13-b5599c74b2dc",
-      "type": "project",
-      "attributes": {
-        "name": "Raymon Wisoky",
-        "description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
-        "recipient_name": "Raymon Wisoky",
-        "website": "http://hane.com/jules",
-        "leadership_demographics": [
-          "i_dont_know",
-          "no_specific_focus"
-        ],
-        "leadership_demographics_other": "Et quaerat omnis veniam.",
-        "demographics": [
-          "i_dont_know",
-          "no_specific_focus"
-        ],
-        "demographics_other": "Et quaerat omnis veniam.",
-        "recipient_legal_status": "cooperative",
-        "recipient_legal_status_other": "Et quaerat omnis veniam.",
-        "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TURZM05ESmlOQzAzT0RRMUxUUTFaVEV0T1RnM055MHlNbVJsTnpReU5HTXhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82fac5e80c7de0830dd68c82e15f1d806dcf254b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TURZM05ESmlOQzAzT0RRMUxUUTFaVEV0T1RnM055MHlNbVJsTnpReU5HTXhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82fac5e80c7de0830dd68c82e15f1d806dcf254b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TURZM05ESmlOQzAzT0RRMUxUUTFaVEV0T1RnM055MHlNbVJsTnpReU5HTXhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--82fac5e80c7de0830dd68c82e15f1d806dcf254b/picture.jpg"
-        }
-      },
-      "relationships": {
-        "state": {
-          "data": {
-            "id": "d6169230-aef4-4c2f-b7f7-49cc807f3541",
-            "type": "subgeographic"
-          }
-        },
-        "country": {
-          "data": {
-            "id": "18bf4166-f286-45b9-9d8b-7070dc5d1d16",
-            "type": "subgeographic"
-          }
-        },
-        "subgeographics": {
-          "data": [
-
-          ]
-        },
-        "subgeographic_ancestors": {
-          "data": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "f20bf0a9-1f55-460e-aa19-5e3094d2e032",
-      "type": "project",
-      "attributes": {
-        "name": "Elbert Denesik",
-        "description": "Dolores fugiat nesciunt. Ut laborum dolores. Sit neque eos. Expedita molestiae quia.",
-        "recipient_name": "Elbert Denesik",
-        "website": "http://hilpert.biz/drusilla",
-        "leadership_demographics": [
-          "i_dont_know",
-          "white"
-        ],
-        "leadership_demographics_other": "Dolores fugiat nesciunt accusantium.",
-        "demographics": [
-          "i_dont_know",
-          "white"
-        ],
-        "demographics_other": "Dolores fugiat nesciunt accusantium.",
-        "recipient_legal_status": "cooperative",
-        "recipient_legal_status_other": "Dolores fugiat nesciunt accusantium.",
-        "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RNeU1UYzBNQzB5WWpNeUxUUXdPREF0T0RGaE9DMDBOR0V3TWprd01HWXhZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--14e8d24eec15025767d194bf05261bdb06d75f54/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RNeU1UYzBNQzB5WWpNeUxUUXdPREF0T0RGaE9DMDBOR0V3TWprd01HWXhZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--14e8d24eec15025767d194bf05261bdb06d75f54/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6T0RNeU1UYzBNQzB5WWpNeUxUUXdPREF0T0RGaE9DMDBOR0V3TWprd01HWXhZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--14e8d24eec15025767d194bf05261bdb06d75f54/picture.jpg"
-        }
-      },
-      "relationships": {
-        "state": {
-          "data": {
-            "id": "41cdc49c-6134-49f7-91e4-1717dac5eab8",
-            "type": "subgeographic"
-          }
-        },
-        "country": {
-          "data": {
-            "id": "899b411d-5bc5-4302-8723-ddef8761e84b",
+            "id": "168b539e-7608-431d-b943-0164fafe54dd",
             "type": "subgeographic"
           }
         },
         "subgeographics": {
           "data": [
             {
-              "id": "d387533e-76e0-4f77-b476-4b0d0634ce23",
+              "id": "f6de56ca-e2c5-4014-841e-c0d2fb9395ac",
               "type": "subgeographic"
             }
           ]
@@ -203,16 +203,29 @@
         "subgeographic_ancestors": {
           "data": [
             {
-              "id": "d387533e-76e0-4f77-b476-4b0d0634ce23",
+              "id": "f6de56ca-e2c5-4014-841e-c0d2fb9395ac",
               "type": "subgeographic"
             },
             {
-              "id": "884bf29d-3408-4b8f-bbeb-c7858df7aa8a",
+              "id": "a5b1cf08-46e3-49a2-b72a-c4086298dca4",
               "type": "subgeographic"
             }
           ]
         }
       }
     }
-  ]
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "from": 1,
+    "to": 4,
+    "total": 4,
+    "pages": 1
+  },
+  "links": {
+    "first": "/api/v1/projects?page%5Bsize%5D=10",
+    "self": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  }
 }

--- a/backend/spec/fixtures/snapshots/api/v1/projects.json
+++ b/backend/spec/fixtures/snapshots/api/v1/projects.json
@@ -1,160 +1,7 @@
 {
   "data": [
     {
-      "id": "8ff3eaeb-4f98-46d3-8b20-17907adc4ea6",
-      "type": "project",
-      "attributes": {
-        "name": "Otha Kemmer",
-        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
-        "recipient_name": "Otha Kemmer",
-        "website": "http://kutch-spencer.com/moises",
-        "leadership_demographics": [
-          "hispanic_or_latinx",
-          "other"
-        ],
-        "leadership_demographics_other": "Enim repellat pariatur est.",
-        "demographics": [
-          "hispanic_or_latinx",
-          "other"
-        ],
-        "demographics_other": "Enim repellat pariatur est.",
-        "recipient_legal_status": "for_profit",
-        "recipient_legal_status_other": "Enim repellat pariatur est.",
-        "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/picture.jpg"
-        }
-      },
-      "relationships": {
-        "state": {
-          "data": {
-            "id": "eb94a7a7-15f1-4ab2-94d2-934521fa29bd",
-            "type": "subgeographic"
-          }
-        },
-        "country": {
-          "data": {
-            "id": "c562c45a-bc09-4d25-839c-3d27f72efc4f",
-            "type": "subgeographic"
-          }
-        },
-        "subgeographics": {
-          "data": [
-
-          ]
-        },
-        "subgeographic_ancestors": {
-          "data": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "9199a4f4-1d63-46d2-8b0d-5e441645dc07",
-      "type": "project",
-      "attributes": {
-        "name": "Msgr. Genaro Cronin",
-        "description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
-        "recipient_name": "Otha Kemmer",
-        "website": "http://kutch-spencer.com/moises",
-        "leadership_demographics": [
-          "hispanic_or_latinx",
-          "other"
-        ],
-        "leadership_demographics_other": "Enim repellat pariatur est.",
-        "demographics": [
-          "hispanic_or_latinx",
-          "other"
-        ],
-        "demographics_other": "Enim repellat pariatur est.",
-        "recipient_legal_status": "for_profit",
-        "recipient_legal_status_other": "Enim repellat pariatur est.",
-        "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/picture.jpg"
-        }
-      },
-      "relationships": {
-        "state": {
-          "data": {
-            "id": "eb94a7a7-15f1-4ab2-94d2-934521fa29bd",
-            "type": "subgeographic"
-          }
-        },
-        "country": {
-          "data": {
-            "id": "c562c45a-bc09-4d25-839c-3d27f72efc4f",
-            "type": "subgeographic"
-          }
-        },
-        "subgeographics": {
-          "data": [
-
-          ]
-        },
-        "subgeographic_ancestors": {
-          "data": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "7cb9f8d3-6ce1-4d26-a559-1cfeac3dab00",
-      "type": "project",
-      "attributes": {
-        "name": "Raymon Wisoky",
-        "description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
-        "recipient_name": "Otha Kemmer",
-        "website": "http://kutch-spencer.com/moises",
-        "leadership_demographics": [
-          "hispanic_or_latinx",
-          "other"
-        ],
-        "leadership_demographics_other": "Enim repellat pariatur est.",
-        "demographics": [
-          "hispanic_or_latinx",
-          "other"
-        ],
-        "demographics_other": "Enim repellat pariatur est.",
-        "recipient_legal_status": "for_profit",
-        "recipient_legal_status_other": "Enim repellat pariatur est.",
-        "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqTTJNMk1HWTVaQzB6Wm1FNExUUmtOemN0WVRsaU5TMWtaR00zT0dRNU5XWTJZemNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--c687f3f6210f6f95dbee56540a6b4ebe7fae268c/picture.jpg"
-        }
-      },
-      "relationships": {
-        "state": {
-          "data": {
-            "id": "eb94a7a7-15f1-4ab2-94d2-934521fa29bd",
-            "type": "subgeographic"
-          }
-        },
-        "country": {
-          "data": {
-            "id": "c562c45a-bc09-4d25-839c-3d27f72efc4f",
-            "type": "subgeographic"
-          }
-        },
-        "subgeographics": {
-          "data": [
-
-          ]
-        },
-        "subgeographic_ancestors": {
-          "data": [
-
-          ]
-        }
-      }
-    },
-    {
-      "id": "03a0736a-2066-4101-81b2-028766523386",
+      "id": "e39a5ad0-0724-465d-9a1f-920b59ec3872",
       "type": "project",
       "attributes": {
         "name": "Elbert Denesik",
@@ -174,28 +21,28 @@
         "recipient_legal_status": "foundation",
         "recipient_legal_status_other": "Placeat commodi libero et.",
         "logo": {
-          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RFd1ltTXlOQzAzTVdNeExUUmtNbU10T1dVM1ppMHdPVGN5T0dJMU5qSTNNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7f250ce1e6c30ebc522b08d0365aa6ad722bb877/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
-          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RFd1ltTXlOQzAzTVdNeExUUmtNbU10T1dVM1ppMHdPVGN5T0dJMU5qSTNNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7f250ce1e6c30ebc522b08d0365aa6ad722bb877/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
-          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpT0RFd1ltTXlOQzAzTVdNeExUUmtNbU10T1dVM1ppMHdPVGN5T0dJMU5qSTNNamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--7f250ce1e6c30ebc522b08d0365aa6ad722bb877/picture.jpg"
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkROaE9UaG1ZeTA1TTJWakxUUmpNakF0WW1NelpDMWxNVFF3WXpjMVpURmhOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e83ef2fcb65d18707df0978f41dc468df3863c5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkROaE9UaG1ZeTA1TTJWakxUUmpNakF0WW1NelpDMWxNVFF3WXpjMVpURmhOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e83ef2fcb65d18707df0978f41dc468df3863c5/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4WkROaE9UaG1ZeTA1TTJWakxUUmpNakF0WW1NelpDMWxNVFF3WXpjMVpURmhOV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e83ef2fcb65d18707df0978f41dc468df3863c5/picture.jpg"
         }
       },
       "relationships": {
         "state": {
           "data": {
-            "id": "02c0d71b-b0be-471f-ac06-29e077f3535e",
+            "id": "f3c5f703-570b-4177-99a7-7111fb84d595",
             "type": "subgeographic"
           }
         },
         "country": {
           "data": {
-            "id": "168b539e-7608-431d-b943-0164fafe54dd",
+            "id": "4d4ff681-56cc-49bd-899b-9aac8148b4ba",
             "type": "subgeographic"
           }
         },
         "subgeographics": {
           "data": [
             {
-              "id": "f6de56ca-e2c5-4014-841e-c0d2fb9395ac",
+              "id": "42686ddd-e555-4e98-ab28-26e190f258b0",
               "type": "subgeographic"
             }
           ]
@@ -203,13 +50,166 @@
         "subgeographic_ancestors": {
           "data": [
             {
-              "id": "f6de56ca-e2c5-4014-841e-c0d2fb9395ac",
+              "id": "42686ddd-e555-4e98-ab28-26e190f258b0",
               "type": "subgeographic"
             },
             {
-              "id": "a5b1cf08-46e3-49a2-b72a-c4086298dca4",
+              "id": "2250413e-baaa-4f10-8d9d-faa23c3bde2d",
               "type": "subgeographic"
             }
+          ]
+        }
+      }
+    },
+    {
+      "id": "818c847c-3306-4590-81c2-e00c27087f3b",
+      "type": "project",
+      "attributes": {
+        "name": "Msgr. Genaro Cronin",
+        "description": "Placeat commodi libero. Quo recusandae repellat. Sunt commodi tempore. Voluptatem et corrupti.",
+        "recipient_name": "Otha Kemmer",
+        "website": "http://kutch-spencer.com/moises",
+        "leadership_demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "leadership_demographics_other": "Enim repellat pariatur est.",
+        "demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "demographics_other": "Enim repellat pariatur est.",
+        "recipient_legal_status": "for_profit",
+        "recipient_legal_status_other": "Enim repellat pariatur est.",
+        "logo": {
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/picture.jpg"
+        }
+      },
+      "relationships": {
+        "state": {
+          "data": {
+            "id": "9817fd55-5c7b-46f2-8380-a6c82d4547c9",
+            "type": "subgeographic"
+          }
+        },
+        "country": {
+          "data": {
+            "id": "b3cb8cbf-72a8-42cf-af0e-52bfc272d69f",
+            "type": "subgeographic"
+          }
+        },
+        "subgeographics": {
+          "data": [
+
+          ]
+        },
+        "subgeographic_ancestors": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "63ad625d-d616-4620-83ca-4bde292baf2c",
+      "type": "project",
+      "attributes": {
+        "name": "Otha Kemmer",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem. Qui dolorem quo.",
+        "recipient_name": "Otha Kemmer",
+        "website": "http://kutch-spencer.com/moises",
+        "leadership_demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "leadership_demographics_other": "Enim repellat pariatur est.",
+        "demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "demographics_other": "Enim repellat pariatur est.",
+        "recipient_legal_status": "for_profit",
+        "recipient_legal_status_other": "Enim repellat pariatur est.",
+        "logo": {
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/picture.jpg"
+        }
+      },
+      "relationships": {
+        "state": {
+          "data": {
+            "id": "9817fd55-5c7b-46f2-8380-a6c82d4547c9",
+            "type": "subgeographic"
+          }
+        },
+        "country": {
+          "data": {
+            "id": "b3cb8cbf-72a8-42cf-af0e-52bfc272d69f",
+            "type": "subgeographic"
+          }
+        },
+        "subgeographics": {
+          "data": [
+
+          ]
+        },
+        "subgeographic_ancestors": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "2c34b254-09c9-4716-8ae3-d12975ff5d55",
+      "type": "project",
+      "attributes": {
+        "name": "Raymon Wisoky",
+        "description": "Et quaerat omnis. Harum voluptas atque. Quo nesciunt voluptas. Suscipit ex cum.",
+        "recipient_name": "Otha Kemmer",
+        "website": "http://kutch-spencer.com/moises",
+        "leadership_demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "leadership_demographics_other": "Enim repellat pariatur est.",
+        "demographics": [
+          "hispanic_or_latinx",
+          "other"
+        ],
+        "demographics_other": "Enim repellat pariatur est.",
+        "recipient_legal_status": "for_profit",
+        "recipient_legal_status_other": "Enim repellat pariatur est.",
+        "logo": {
+          "small": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg",
+          "medium": "http://localhost:4000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg",
+          "original": "http://localhost:4000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWm1GaE4yUTVNaTB5WVRjMUxUUmlZek10T1dKaE5TMDRNbVZpTjJZeFpqazVZVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--1ed68cffc86e464d7646fef14ace561d773a4530/picture.jpg"
+        }
+      },
+      "relationships": {
+        "state": {
+          "data": {
+            "id": "9817fd55-5c7b-46f2-8380-a6c82d4547c9",
+            "type": "subgeographic"
+          }
+        },
+        "country": {
+          "data": {
+            "id": "b3cb8cbf-72a8-42cf-af0e-52bfc272d69f",
+            "type": "subgeographic"
+          }
+        },
+        "subgeographics": {
+          "data": [
+
+          ]
+        },
+        "subgeographic_ancestors": {
+          "data": [
+
           ]
         }
       }

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -9,4 +9,40 @@ RSpec.describe Project, type: :model do
     subject.recipient = nil
     expect(subject).to have(1).errors_on(:recipient)
   end
+
+  describe "scopes" do
+    describe ".for_subgeographics" do
+      let!(:country) { create :subgeographic, geographic: :countries }
+      let!(:region) { create :subgeographic, geographic: :regions, parent: country }
+
+      let!(:correct_project) { create :project, recipient: create(:recipient, subgeographics: [region]) }
+      let!(:ignored_project) { create :project }
+
+      it "returns correct result for current subgeographic" do
+        expect(Project.for_subgeographics(region.reload.abbreviation)).to eq([correct_project])
+      end
+
+      it "returns correct result for ancestor subgeographic" do
+        expect(Project.for_subgeographics(country.reload.abbreviation)).to eq([correct_project])
+      end
+    end
+
+    describe ".for_geographics" do
+      let!(:country) { create :subgeographic, geographic: :countries }
+      let!(:region) { create :subgeographic, geographic: :regions, parent: country }
+      let!(:national) { create :subgeographic, geographic: :national, parent: country }
+
+      let!(:project_1) { create :project, recipient: create(:recipient, subgeographics: [region]) }
+      let!(:project_2) { create :project, recipient: create(:recipient, subgeographics: [national]) }
+
+      it "returns correct result for current geographic" do
+        expect(Project.for_geographics(:regions)).to eq([project_1])
+        expect(Project.for_geographics(:national)).to eq([project_2])
+      end
+
+      it "returns correct result for ancestor geographic" do
+        expect(Project.for_geographics(:countries)).to match_array([project_1, project_2])
+      end
+    end
+  end
 end

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -44,5 +44,17 @@ RSpec.describe Project, type: :model do
         expect(Project.for_geographics(:countries)).to match_array([project_1, project_2])
       end
     end
+
+    describe ".with_funders_count" do
+      let!(:project) { create :project }
+      let!(:project_without_funder) { create :project }
+      let!(:investments) { create_list :investment, 2, project: project }
+      let!(:investment_of_same_funder) { create :investment, project: project, funder: investments.first.funder }
+
+      it "shows counts correct number of projects" do
+        expect(Project.with_funders_count.find(project.id).funders_count).to eq(investments.count)
+        expect(Project.with_funders_count.find(project_without_funder.id).funders_count).to be_zero
+      end
+    end
   end
 end

--- a/backend/spec/requests/api/v1/funders_spec.rb
+++ b/backend/spec/requests/api/v1/funders_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "API V1 Funders", type: :request do
         context "when filtered by full text search" do
           let("filter[full_text]") { funder.name }
 
-          it "returns only funders at correct areas" do
+          it "returns only funders with appropriate name" do
             expect(response_json["data"].pluck("id")).to eq([funder.id])
           end
         end

--- a/backend/spec/requests/api/v1/funders_spec.rb
+++ b/backend/spec/requests/api/v1/funders_spec.rb
@@ -160,6 +160,7 @@ RSpec.describe "API V1 Funders", type: :request do
       let(:country) { create :subgeographic, geographic: :countries }
       let!(:national) { create :subgeographic, geographic: :national, parent: country }
       let!(:funder) { create :funder, subgeographics: [national] }
+      let!(:invisible_investment) { create :investment, funder: funder, visible: false }
       let(:id) { funder.id }
 
       it_behaves_like "with not found error"
@@ -171,6 +172,10 @@ RSpec.describe "API V1 Funders", type: :request do
 
         it "matches snapshot", generate_swagger_example: true do
           expect(response.body).to match_snapshot("api/v1/get-funder")
+        end
+
+        it "does not show invisible investment" do
+          expect(response_json["data"]["relationships"]["investments"]["data"].pluck("id")).not_to include(invisible_investment.id)
         end
 
         context "with sparse fieldset" do

--- a/backend/spec/requests/api/v1/projects_spec.rb
+++ b/backend/spec/requests/api/v1/projects_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "API V1 Projects", type: :request do
       parameter name: "filter[areas]", in: :query, type: :string, enum: Area::TYPES, description: "Filter results only for specified areas. Use comma to separate multiple fields", required: false
       parameter name: "filter[demographics]", in: :query, type: :string, enum: Demographic::TYPES, description: "Filter results only for specified demographics. Use comma to separate multiple fields", required: false
       parameter name: "filter[recipient_legal_statuses]", in: :query, type: :string, enum: RecipientLegalStatus::TYPES, description: "Filter results only for specified recipient legal status. Use comma to separate multiple fields", required: false
+      parameter name: "page[number]", in: :query, type: :integer, description: "Page number. Default: 1", required: false
+      parameter name: "page[size]", in: :query, type: :integer, description: "Per page items. Default: 10", required: false
+      parameter name: :disable_pagination, in: :query, type: :boolean, description: "Turn off pagination", required: false
       parameter name: "fields[project]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
       parameter name: :includes, in: :query, type: :string, description: "Include relationships. Use comma to separate multiple fields", required: false
 
@@ -27,10 +30,14 @@ RSpec.describe "API V1 Projects", type: :request do
 
       response "200", :success do
         schema type: :object, properties: {
-          data: {type: :array, items: {"$ref" => "#/components/schemas/project"}}
+          data: {type: :array, items: {"$ref" => "#/components/schemas/project"}},
+          meta: {"$ref" => "#/components/schemas/pagination_meta", :nullable => true},
+          links: {"$ref" => "#/components/schemas/pagination_links", :nullable => true}
         }
 
         run_test!
+
+        it_behaves_like "with pagination", expected_total: 4
 
         it "matches snapshot", generate_swagger_example: true do
           expect(response.body).to match_snapshot("api/v1/projects")
@@ -50,6 +57,17 @@ RSpec.describe "API V1 Projects", type: :request do
 
           it "matches snapshot" do
             expect(response.body).to match_snapshot("api/v1/projects-include-relationships")
+          end
+        end
+
+        context "when disabling pagination" do
+          let("page[size]") { 1 }
+          let(:disable_pagination) { true }
+
+          it "shows all records" do
+            expect(response_json["data"].size).to eq(Project.count)
+            expect(response_json["meta"]).to be_nil
+            expect(response_json["links"]).to be_nil
           end
         end
 

--- a/backend/spec/requests/api/v1/projects_spec.rb
+++ b/backend/spec/requests/api/v1/projects_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "API V1 Projects", type: :request do
       parameter name: "filter[areas]", in: :query, type: :string, enum: Area::TYPES, description: "Filter results only for specified areas. Use comma to separate multiple fields", required: false
       parameter name: "filter[demographics]", in: :query, type: :string, enum: Demographic::TYPES, description: "Filter results only for specified demographics. Use comma to separate multiple fields", required: false
       parameter name: "filter[recipient_legal_statuses]", in: :query, type: :string, enum: RecipientLegalStatus::TYPES, description: "Filter results only for specified recipient legal status. Use comma to separate multiple fields", required: false
+      parameter name: "filter[full_text]", in: :query, type: :string, description: "Filter records by provided text", required: false
       parameter name: "page[number]", in: :query, type: :integer, description: "Page number. Default: 1", required: false
       parameter name: "page[size]", in: :query, type: :integer, description: "Per page items. Default: 10", required: false
       parameter name: :disable_pagination, in: :query, type: :boolean, description: "Turn off pagination", required: false
@@ -105,11 +106,20 @@ RSpec.describe "API V1 Projects", type: :request do
           end
         end
 
+        context "when filtered by full text search" do
+          let("filter[full_text]") { project.name }
+
+          it "returns only projects with appropriate name" do
+            expect(response_json["data"].pluck("id")).to eq([project.id])
+          end
+        end
+
         context "when combining multiple filters" do
           let("filter[subgeographics]") { national.abbreviation }
           let("filter[geographic]") { :national }
           let("filter[areas]") { "food_sovereignty" }
           let("filter[recipient_legal_statuses]") { "foundation" }
+          let("filter[full_text]") { project.name }
 
           it "returns only projects which are true for all filters" do
             expect(response_json["data"].pluck("id")).to eq([project.id])

--- a/backend/spec/requests/api/v1/projects_spec.rb
+++ b/backend/spec/requests/api/v1/projects_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "API V1 Projects", type: :request do
       parameter name: "filter[full_text]", in: :query, type: :string, description: "Filter records by provided text", required: false
       parameter name: "page[number]", in: :query, type: :integer, description: "Page number. Default: 1", required: false
       parameter name: "page[size]", in: :query, type: :integer, description: "Per page items. Default: 10", required: false
+      parameter name: "sort[attribute]", in: :query, type: :string, enum: API::V1::ProjectsController::SORTING_COLUMNS, description: "Attributes usable for sorting. Default: created_at", required: false
+      parameter name: "sort[direction]", in: :query, type: :string, enum: API::Sorting::SORTING_DIRECTIONS, description: "Possible directions of sorting. Default: desc", required: false
       parameter name: :disable_pagination, in: :query, type: :boolean, description: "Turn off pagination", required: false
       parameter name: "fields[project]", in: :query, type: :string, description: "Get only required fields. Use comma to separate multiple fields", required: false
       parameter name: :includes, in: :query, type: :string, description: "Include relationships. Use comma to separate multiple fields", required: false
@@ -35,6 +37,8 @@ RSpec.describe "API V1 Projects", type: :request do
           meta: {"$ref" => "#/components/schemas/pagination_meta", :nullable => true},
           links: {"$ref" => "#/components/schemas/pagination_links", :nullable => true}
         }
+        let("sort[attribute]") { "name" }
+        let("sort[direction]") { "asc" }
 
         run_test!
 
@@ -123,6 +127,23 @@ RSpec.describe "API V1 Projects", type: :request do
 
           it "returns only projects which are true for all filters" do
             expect(response_json["data"].pluck("id")).to eq([project.id])
+          end
+        end
+
+        context "when sorting by funders count" do
+          let(:project_1) { projects.first }
+          let(:project_2) { project }
+          let!(:investments_1) { create_list :investment, 2, project: project_1 }
+          let!(:investments_2) { create_list :investment, 1, project: project_2 }
+
+          let("sort[attribute]") { "funders_count" }
+          let("sort[direction]") { "desc" }
+
+          run_test!
+
+          it "returns correctly sorted result" do
+            expect(response_json["data"].first["id"]).to eq(project_1.id)
+            expect(response_json["data"].second["id"]).to eq(project_2.id)
           end
         end
       end

--- a/backend/spec/requests/api/v1/projects_spec.rb
+++ b/backend/spec/requests/api/v1/projects_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe "API V1 Projects", type: :request do
         end
 
         context "with relationships" do
-          let("fields[project]") { "name,subgeographics,nonexisting" }
-          let(:includes) { "subgeographics" }
+          let("fields[project]") { "name,subgeographics,investments,nonexisting" }
+          let(:includes) { "subgeographics,investments" }
 
           it "matches snapshot" do
             expect(response.body).to match_snapshot("api/v1/projects-include-relationships")

--- a/backend/spec/services/api/enum_filter_spec.rb
+++ b/backend/spec/services/api/enum_filter_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe API::EnumFilter do
-  subject { described_class.new query, filters }
+  subject { described_class.new query, filters, extra_models: extra_models }
+
+  let(:extra_models) { [] }
 
   describe "#call" do
     context "when using multiple filters on string attributes" do
@@ -43,6 +45,23 @@ RSpec.describe API::EnumFilter do
 
       it "returns correct funder" do
         expect(subject.call).to eq([correct_funder])
+      end
+    end
+
+    context "when filtering on enum attributes from different table" do
+      let!(:correct_project) do
+        create :project, recipient: create(:recipient, recipient_legal_status: "foundation")
+      end
+      let!(:different_recipient_legal_statuses_project) do
+        create :project, recipient: create(:recipient, recipient_legal_status: "for_profit")
+      end
+
+      let(:query) { Project.joins(:recipient) }
+      let(:filters) { {recipient_legal_statuses: "foundation"} }
+      let(:extra_models) { [Recipient] }
+
+      it "returns correct project" do
+        expect(subject.call).to eq([correct_project])
       end
     end
   end

--- a/backend/spec/services/api/sorting_spec.rb
+++ b/backend/spec/services/api/sorting_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe API::Sorting do
   subject { described_class.new query, sorting, columns }
 
   describe "#call" do
-    let!(:funder_1) { create :funder, name: "BBBB", description: "BBBB", created_at: 1.day.ago, updated_at: 1.day.ago }
-    let!(:funder_2) { create :funder, name: "AAAA", description: "AAAA", created_at: Time.current, updated_at: Time.current }
+    let!(:funder_1) { create :funder, name: "BBBB", description: "BBBB", created_at: 1.day.ago }
+    let!(:funder_2) { create :funder, name: "AAAA", description: "AAAA", created_at: Time.current }
     let(:query) { Funder.all }
     let(:columns) { %i[name] }
 
@@ -13,7 +13,7 @@ RSpec.describe API::Sorting do
       let(:sorting) { {attribute: :description} }
 
       it "returns data for original query" do
-        expect(subject.call.to_a).to eq([funder_1, funder_2])
+        expect(subject.call.order(:created_at).to_a).to eq([funder_1, funder_2])
       end
     end
 

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -70,7 +70,8 @@ RSpec.configure do |config|
                   primary_office_state: {"$ref" => "#/components/schemas/nullable_response_relation"},
                   primary_office_country: {"$ref" => "#/components/schemas/response_relation"},
                   subgeographics: {"$ref" => "#/components/schemas/response_relations"},
-                  subgeographic_ancestors: {"$ref" => "#/components/schemas/response_relations"}
+                  subgeographic_ancestors: {"$ref" => "#/components/schemas/response_relations"},
+                  investments: {"$ref" => "#/components/schemas/response_relations"}
                 }
               }
             },
@@ -103,7 +104,8 @@ RSpec.configure do |config|
                   state: {"$ref" => "#/components/schemas/nullable_response_relation"},
                   country: {"$ref" => "#/components/schemas/response_relation"},
                   subgeographics: {"$ref" => "#/components/schemas/response_relations"},
-                  subgeographic_ancestors: {"$ref" => "#/components/schemas/response_relations"}
+                  subgeographic_ancestors: {"$ref" => "#/components/schemas/response_relations"},
+                  investments: {"$ref" => "#/components/schemas/response_relations"}
                 }
               }
             },

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -720,7 +720,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: 6d663da5-7dc9-45c4-ba95-f60f754ba910
+                - id: 4f50b87e-a57c-4f8b-8882-7512d1174232
                   type: funder
                   attributes:
                     name: Elbert Denesik
@@ -734,7 +734,7 @@ paths:
                     primary_contact_location: 851 Drusilla Lodge, Port Randy, VT 43075
                     primary_contact_role: intermediary
                     website: http://hilpert.biz/drusilla
-                    date_joined_fora: '2022-02-18T00:00:00.000Z'
+                    date_joined_fora: '2022-02-21T00:00:00.000Z'
                     funder_type: accelerator
                     funder_type_other: Dolores fugiat nesciunt accusantium.
                     capital_acceptances:
@@ -766,29 +766,31 @@ paths:
                     demographics_other: Dolores fugiat nesciunt accusantium.
                     contact_email: lauren@ruecker.io
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRRellqZGlNQzA0T0dOaUxUUTVNelF0T0RKaE1pMDNPREkxWVRCbU5UQXdNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2782df8278c2e9b58b43a1fa5931961c17492c19/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRRellqZGlNQzA0T0dOaUxUUTVNelF0T0RKaE1pMDNPREkxWVRCbU5UQXdNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2782df8278c2e9b58b43a1fa5931961c17492c19/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxtWkRRellqZGlNQzA0T0dOaUxUUTVNelF0T0RKaE1pMDNPREkxWVRCbU5UQXdNMk1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--2782df8278c2e9b58b43a1fa5931961c17492c19/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWXpReU5HSTJOaTFsTnpJMkxUUXhNRGd0T0RrM055MDRaakEwWTJZd01XUmlaRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f057f896e39848cdf4e80520f2ce504c63a7066e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWXpReU5HSTJOaTFsTnpJMkxUUXhNRGd0T0RrM055MDRaakEwWTJZd01XUmlaRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f057f896e39848cdf4e80520f2ce504c63a7066e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswWXpReU5HSTJOaTFsTnpJMkxUUXhNRGd0T0RrM055MDRaakEwWTJZd01XUmlaRElHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f057f896e39848cdf4e80520f2ce504c63a7066e/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: e9f71af0-4a7c-42e1-a9d2-2d94bdce7fe6
+                        id: 8efae06a-3229-461e-b9a5-ea9bc6e54d5f
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: e6c9961e-66e3-44a6-8e55-1b9a1cab2e06
+                        id: 2e17142a-1bf8-47ba-a947-e63008156cd2
                         type: subgeographic
                     subgeographics:
                       data:
-                      - id: cb9dd7ba-d63b-4511-8b22-c8d24959765d
+                      - id: 2e9a325c-812f-4dea-ba2e-9a6a66d394aa
                         type: subgeographic
                     subgeographic_ancestors:
                       data:
-                      - id: cb9dd7ba-d63b-4511-8b22-c8d24959765d
+                      - id: 2e9a325c-812f-4dea-ba2e-9a6a66d394aa
                         type: subgeographic
-                      - id: 4edeca73-dc7f-4049-a213-c563f032952b
+                      - id: ea0cfe41-e344-4ae7-9f53-7e49b8f4f756
                         type: subgeographic
-                - id: 1bcd381a-81f3-4b4e-bd75-37457f9e63b9
+                    investments:
+                      data: []
+                - id: 14001519-27c8-4f69-9e8e-1dd1eccb8353
                   type: funder
                   attributes:
                     name: Msgr. Genaro Cronin
@@ -803,7 +805,7 @@ paths:
                       44573
                     primary_contact_role: funder
                     website: http://bartoletti.com/jeremiah_cronin
-                    date_joined_fora: '2022-04-05T00:00:00.000Z'
+                    date_joined_fora: '2022-04-08T00:00:00.000Z'
                     funder_type: advisory
                     funder_type_other: Placeat commodi libero et.
                     capital_acceptances:
@@ -835,23 +837,25 @@ paths:
                     demographics_other: Placeat commodi libero et.
                     contact_email: desmond_herzog@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0Rsa01HVTRNaTAyWTJWbUxUUTBOR010WWpJeVpTMDRObUZpTVRnek5EazBOR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--de8c09097bc88bf6d284cd1d1761d2bd97d98b73/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0Rsa01HVTRNaTAyWTJWbUxUUTBOR010WWpJeVpTMDRObUZpTVRnek5EazBOR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--de8c09097bc88bf6d284cd1d1761d2bd97d98b73/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT0Rsa01HVTRNaTAyWTJWbUxUUTBOR010WWpJeVpTMDRObUZpTVRnek5EazBOR0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--de8c09097bc88bf6d284cd1d1761d2bd97d98b73/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTlRRNE1ERXdZUzB5TmpNekxUUXlOek10T1Rjd1lpMHpNVGt6TkdaaVlUUXhZV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ce25e94ceb0dad9d907bdfa3a6d409ce328f5aba/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTlRRNE1ERXdZUzB5TmpNekxUUXlOek10T1Rjd1lpMHpNVGt6TkdaaVlUUXhZV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ce25e94ceb0dad9d907bdfa3a6d409ce328f5aba/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxpTlRRNE1ERXdZUzB5TmpNekxUUXlOek10T1Rjd1lpMHpNVGt6TkdaaVlUUXhZV1FHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--ce25e94ceb0dad9d907bdfa3a6d409ce328f5aba/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 00f9d1e2-858f-499d-8a89-4581056a16c2
+                        id: 6fec4182-3c04-4698-81f6-aea9dc0d6461
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: a47924b6-0487-41ca-81b1-6817de560e41
+                        id: 119e9a68-6098-4f5a-a528-19575a889ded
                         type: subgeographic
                     subgeographics:
                       data: []
                     subgeographic_ancestors:
                       data: []
-                - id: 9985ec98-dd79-41ef-a078-24c69c6f77c1
+                    investments:
+                      data: []
+                - id: f48d95f9-cba0-4d1d-808b-6df7b9edbb03
                   type: funder
                   attributes:
                     name: Otha Kemmer
@@ -866,7 +870,7 @@ paths:
                       WY 06997-6910
                     primary_contact_role: regrantor
                     website: http://kutch-spencer.com/moises
-                    date_joined_fora: '2021-11-25T00:00:00.000Z'
+                    date_joined_fora: '2021-11-28T00:00:00.000Z'
                     funder_type: advisory
                     funder_type_other: Enim repellat pariatur est.
                     capital_acceptances:
@@ -898,23 +902,25 @@ paths:
                     demographics_other: Enim repellat pariatur est.
                     contact_email: dawna.block@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqT0RZNU5UTXpaUzFqTW1OaExUUXlORE10T0RGbE5pMHdaamcwWm1JM1pqY3lOakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4b2824685de315f053796635f447c162b1656943/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqT0RZNU5UTXpaUzFqTW1OaExUUXlORE10T0RGbE5pMHdaamcwWm1JM1pqY3lOakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4b2824685de315f053796635f447c162b1656943/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxqT0RZNU5UTXpaUzFqTW1OaExUUXlORE10T0RGbE5pMHdaamcwWm1JM1pqY3lOakFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4b2824685de315f053796635f447c162b1656943/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTmpGbU1tRXdZUzAxWWpobUxUUmlNVGt0WVdJM01TMDVPV1poWVdFMlpEa3hZek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--274b9c04c0e3fa83ccabf064c345ad05e4aea857/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTmpGbU1tRXdZUzAxWWpobUxUUmlNVGt0WVdJM01TMDVPV1poWVdFMlpEa3hZek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--274b9c04c0e3fa83ccabf064c345ad05e4aea857/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxoTmpGbU1tRXdZUzAxWWpobUxUUmlNVGt0WVdJM01TMDVPV1poWVdFMlpEa3hZek1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--274b9c04c0e3fa83ccabf064c345ad05e4aea857/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 8be2732a-aec3-41fa-99a8-0ae3a908a99b
+                        id: d33e9076-0eb1-48b7-a57f-3e178fa8738c
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: dc201b49-ec0a-45e9-95e5-44cf2c1d2ed5
+                        id: 2ce9a900-939f-4ec0-9e6e-ca3a29653a9f
                         type: subgeographic
                     subgeographics:
                       data: []
                     subgeographic_ancestors:
                       data: []
-                - id: cd85ffdd-104b-4595-89a1-fc4afa87da80
+                    investments:
+                      data: []
+                - id: cb8c76a0-2ec5-411e-86dd-40513d28b0f3
                   type: funder
                   attributes:
                     name: Raymon Wisoky
@@ -929,7 +935,7 @@ paths:
                       60478-1622
                     primary_contact_role: intermediary
                     website: http://hane.com/jules
-                    date_joined_fora: '2022-03-20T00:00:00.000Z'
+                    date_joined_fora: '2022-03-23T00:00:00.000Z'
                     funder_type: advisory
                     funder_type_other: Et quaerat omnis veniam.
                     capital_acceptances:
@@ -961,21 +967,23 @@ paths:
                     demographics_other: Et quaerat omnis veniam.
                     contact_email: jules_keeling@grimes-stokes.co
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWWpnd01qRXdZaTB6TmpFMExUUXhNVGN0T1RsaU5DMDBPV0ppTURJM05qUmlPR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4d08ad4f6b42037780ef5ce959dbad2b4b1973bf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWWpnd01qRXdZaTB6TmpFMExUUXhNVGN0T1RsaU5DMDBPV0ppTURJM05qUmlPR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4d08ad4f6b42037780ef5ce959dbad2b4b1973bf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWWpnd01qRXdZaTB6TmpFMExUUXhNVGN0T1RsaU5DMDBPV0ppTURJM05qUmlPR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--4d08ad4f6b42037780ef5ce959dbad2b4b1973bf/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T1RVek5UUTBZUzB3WWpjNExUUXdOall0WVdNMFpTMHpOMk0yTURFd05HVm1PR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f6d1a988c823fe66b538b14df02758ac9bff7db8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T1RVek5UUTBZUzB3WWpjNExUUXdOall0WVdNMFpTMHpOMk0yTURFd05HVm1PR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f6d1a988c823fe66b538b14df02758ac9bff7db8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T1RVek5UUTBZUzB3WWpjNExUUXdOall0WVdNMFpTMHpOMk0yTURFd05HVm1PR0lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f6d1a988c823fe66b538b14df02758ac9bff7db8/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 558e4c9a-8bc4-49fa-a198-400df6de8752
+                        id: 9162b5d3-ec85-434f-84ba-f239efbc2c80
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: '04087a5e-8761-40af-abb0-806574ab8f19'
+                        id: 165ff95b-931d-4e9e-94b8-4540926f0563
                         type: subgeographic
                     subgeographics:
                       data: []
                     subgeographic_ancestors:
+                      data: []
+                    investments:
                       data: []
                 meta:
                   page: 1
@@ -1041,7 +1049,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 71d204f4-c7bd-459a-ac43-ad9bb23a223b
+                  id: 22d96b76-f90d-42ce-b359-c3d4d27491fe
                   type: funder
                   attributes:
                     name: Otha Kemmer
@@ -1056,7 +1064,7 @@ paths:
                       WY 06997-6910
                     primary_contact_role: regrantor
                     website: http://kutch-spencer.com/moises
-                    date_joined_fora: '2021-11-25T00:00:00.000Z'
+                    date_joined_fora: '2021-11-28T00:00:00.000Z'
                     funder_type: funder_collaborative_or_network
                     funder_type_other: Enim repellat pariatur est.
                     capital_acceptances:
@@ -1089,28 +1097,30 @@ paths:
                     demographics_other: Enim repellat pariatur est.
                     contact_email: dawna.block@example.org
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWkRJeVpEQXpNUzB5TUdNMExUUXhOVGN0T1dRNE5TMHlNVEUwWXpjMk9HVmhNVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3b530700143b105f2f21b1af66698c197e2bedf0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWkRJeVpEQXpNUzB5TUdNMExUUXhOVGN0T1dRNE5TMHlNVEUwWXpjMk9HVmhNVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3b530700143b105f2f21b1af66698c197e2bedf0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxsWkRJeVpEQXpNUzB5TUdNMExUUXhOVGN0T1dRNE5TMHlNVEUwWXpjMk9HVmhNVGNHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--3b530700143b105f2f21b1af66698c197e2bedf0/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TnpZME16UTVZeTFpTXpBNUxUUTNObVl0WWpNeE1pMWtabU0xTkdGak5XWTFOekVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a8b3afbc4f69a125aa708d38df84fa78d72b6a15/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TnpZME16UTVZeTFpTXpBNUxUUTNObVl0WWpNeE1pMWtabU0xTkdGak5XWTFOekVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a8b3afbc4f69a125aa708d38df84fa78d72b6a15/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs0TnpZME16UTVZeTFpTXpBNUxUUTNObVl0WWpNeE1pMWtabU0xTkdGak5XWTFOekVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--a8b3afbc4f69a125aa708d38df84fa78d72b6a15/picture.jpg
                   relationships:
                     primary_office_state:
                       data:
-                        id: 2c79bf22-39a1-42f0-8053-dee0de8deed4
+                        id: 59dd495f-66f4-478f-8b33-b4c0c98d68fb
                         type: subgeographic
                     primary_office_country:
                       data:
-                        id: a2d651e4-b5e1-4c79-9fba-42e5a08441cf
+                        id: 10461632-7fcf-4a1e-babe-52eb4ed9a469
                         type: subgeographic
                     subgeographics:
                       data:
-                      - id: 47dacb3b-d502-47a1-9014-842cf3fcace5
+                      - id: 502a8a32-e9ba-4501-a52e-22fe0ff5ac1f
                         type: subgeographic
                     subgeographic_ancestors:
                       data:
-                      - id: 47dacb3b-d502-47a1-9014-842cf3fcace5
+                      - id: 502a8a32-e9ba-4501-a52e-22fe0ff5ac1f
                         type: subgeographic
-                      - id: 5ef24482-e0a5-4816-b88f-16bcaaedd652
+                      - id: 78741c06-e2eb-4628-aff4-b219e5aa8b33
                         type: subgeographic
+                    investments:
+                      data: []
               schema:
                 type: object
                 properties:
@@ -1223,6 +1233,146 @@ paths:
       tags:
       - Projects
       parameters:
+      - name: filter[subgeographics]
+        in: query
+        description: Filter results only for specified subgeographics. Use comma to
+          separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: filter[geographic]
+        in: query
+        description: Filter results only for specified geographic
+        required: false
+        schema:
+          type: string
+      - name: filter[areas]
+        in: query
+        enum:
+        - equity_and_justice
+        - food_sovereignty
+        - rural_economic_health
+        - climate_change
+        - grazing
+        - soil_health
+        - water
+        - biodiversity
+        - land_access
+        - policy_advocacy
+        - movement_building
+        - nutrient_quality_density
+        - research
+        - animal_welfare
+        - aquaculture
+        - soil_measurement_and_technology
+        - middle_of_the_supply_chain_infrastructure
+        - fiber_systems
+        - toxins_reduction
+        - media_communications_narrative_building
+        - technical_assistance_and_business_planning
+        - regenerative_ag_financing
+        - true_cost_accounting
+        - education_youth
+        - education_future_farmers_young_farmers
+        - healthy_food_access
+        - supply_chain_and_market_development
+        - tribal_nations
+        - leadership_development
+        - educating_legislators
+        - policy_lobbying
+        - farm_workers
+        - urban_farming
+        - regenerative_ag_organizing_networks_or_groups
+        - sustainable_or_biological_inputs
+        - on_farm_automation
+        - farm_equipment
+        - land_asset_financing
+        - land_conservation
+        - land_transition
+        - fermentation
+        - alternative_proteins
+        - agroforestry
+        - consumer_packaged_goods
+        - capacity_building
+        - other
+        description: Filter results only for specified areas. Use comma to separate
+          multiple fields
+        required: false
+        schema:
+          type: string
+      - name: filter[demographics]
+        in: query
+        enum:
+        - black_or_african_american
+        - indigenous_tribal_nations
+        - women
+        - youth
+        - asian
+        - hispanic_or_latinx
+        - lgbtq
+        - white
+        - no_specific_focus
+        - other
+        - i_dont_know
+        description: Filter results only for specified demographics. Use comma to
+          separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: filter[recipient_legal_statuses]
+        in: query
+        enum:
+        - for_profit
+        - foundation
+        - cooperative
+        - other
+        description: Filter results only for specified recipient legal status. Use
+          comma to separate multiple fields
+        required: false
+        schema:
+          type: string
+      - name: filter[full_text]
+        in: query
+        description: Filter records by provided text
+        required: false
+        schema:
+          type: string
+      - name: page[number]
+        in: query
+        description: 'Page number. Default: 1'
+        required: false
+        schema:
+          type: integer
+      - name: page[size]
+        in: query
+        description: 'Per page items. Default: 10'
+        required: false
+        schema:
+          type: integer
+      - name: sort[attribute]
+        in: query
+        enum:
+        - name
+        - funders_count
+        description: 'Attributes usable for sorting. Default: created_at'
+        required: false
+        schema:
+          type: string
+      - name: sort[direction]
+        in: query
+        enum:
+        - asc
+        - desc
+        description: 'Possible directions of sorting. Default: desc'
+        required: false
+        schema:
+          type: string
+      - name: disable_pagination
+        in: query
+        description: Turn off pagination
+        required: false
+        schema:
+          type: boolean
       - name: fields[project]
         in: query
         description: Get only required fields. Use comma to separate multiple fields
@@ -1242,7 +1392,89 @@ paths:
             application/json:
               example:
                 data:
-                - id: 569cc795-1fa7-4af4-adda-95e3d5adc05e
+                - id: ba358329-0b9c-4e80-96ed-95ea18f1a1c7
+                  type: project
+                  attributes:
+                    name: Elbert Denesik
+                    description: Dolores fugiat nesciunt. Ut laborum dolores. Sit
+                      neque eos. Expedita molestiae quia.
+                    recipient_name: Msgr. Genaro Cronin
+                    website: http://bartoletti.com/jeremiah_cronin
+                    leadership_demographics:
+                    - no_specific_focus
+                    - other
+                    leadership_demographics_other: Placeat commodi libero et.
+                    demographics:
+                    - no_specific_focus
+                    - other
+                    demographics_other: Placeat commodi libero et.
+                    recipient_legal_status: foundation
+                    recipient_legal_status_other: Placeat commodi libero et.
+                    logo:
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T0RaaE16WXdNeTFtWWpaaExUUmtPVGt0T1dVeFlTMHdNV1JsWVRneFlqSTROelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--73cc8a98d529c5f48133876e2e72a486993fb481/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T0RaaE16WXdNeTFtWWpaaExUUmtPVGt0T1dVeFlTMHdNV1JsWVRneFlqSTROelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--73cc8a98d529c5f48133876e2e72a486993fb481/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWs1T0RaaE16WXdNeTFtWWpaaExUUmtPVGt0T1dVeFlTMHdNV1JsWVRneFlqSTROelFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--73cc8a98d529c5f48133876e2e72a486993fb481/picture.jpg
+                  relationships:
+                    state:
+                      data:
+                        id: c5245c5c-f165-40e5-8ec0-736d2729d7df
+                        type: subgeographic
+                    country:
+                      data:
+                        id: 53593d1a-cdee-4053-8e71-6c6324b44847
+                        type: subgeographic
+                    subgeographics:
+                      data:
+                      - id: ec36777c-0bc3-4f96-8951-2ab91782bad6
+                        type: subgeographic
+                    subgeographic_ancestors:
+                      data:
+                      - id: ec36777c-0bc3-4f96-8951-2ab91782bad6
+                        type: subgeographic
+                      - id: 8d427de7-c90e-4d3e-a3ee-515e436297d2
+                        type: subgeographic
+                    investments:
+                      data:
+                      - id: 21ca039d-2116-4cd5-891e-10030726a2e6
+                        type: investment
+                - id: b8e9957b-d57d-4744-b99f-0557a92cbd7a
+                  type: project
+                  attributes:
+                    name: Msgr. Genaro Cronin
+                    description: Placeat commodi libero. Quo recusandae repellat.
+                      Sunt commodi tempore. Voluptatem et corrupti.
+                    recipient_name: Otha Kemmer
+                    website: http://kutch-spencer.com/moises
+                    leadership_demographics:
+                    - hispanic_or_latinx
+                    - other
+                    leadership_demographics_other: Enim repellat pariatur est.
+                    demographics:
+                    - hispanic_or_latinx
+                    - other
+                    demographics_other: Enim repellat pariatur est.
+                    recipient_legal_status: for_profit
+                    recipient_legal_status_other: Enim repellat pariatur est.
+                    logo:
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/picture.jpg
+                  relationships:
+                    state:
+                      data:
+                        id: '07388061-e546-4451-a05d-0c1855daabc9'
+                        type: subgeographic
+                    country:
+                      data:
+                        id: e96b9c8c-3bdd-44c4-bdb0-47f8b54cd6eb
+                        type: subgeographic
+                    subgeographics:
+                      data: []
+                    subgeographic_ancestors:
+                      data: []
+                    investments:
+                      data: []
+                - id: db79fbc2-e325-4182-8816-e20b03fc65d5
                   type: project
                   attributes:
                     name: Otha Kemmer
@@ -1258,136 +1490,77 @@ paths:
                     - hispanic_or_latinx
                     - other
                     demographics_other: Enim repellat pariatur est.
-                    recipient_legal_status: foundation
+                    recipient_legal_status: for_profit
                     recipient_legal_status_other: Enim repellat pariatur est.
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRJeU1UZzBOUzB5WXpSa0xUUmlNalF0T0RjNE1TMHlNRFl5TURrNVltRTNaR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--45d03231a3bf7f9338f44add7fdd0dc7c99714c0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRJeU1UZzBOUzB5WXpSa0xUUmlNalF0T0RjNE1TMHlNRFl5TURrNVltRTNaR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--45d03231a3bf7f9338f44add7fdd0dc7c99714c0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt6WlRJeU1UZzBOUzB5WXpSa0xUUmlNalF0T0RjNE1TMHlNRFl5TURrNVltRTNaR1VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--45d03231a3bf7f9338f44add7fdd0dc7c99714c0/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/picture.jpg
                   relationships:
                     state:
                       data:
-                        id: a156498c-6dc2-4a44-b207-84795ad39afe
+                        id: '07388061-e546-4451-a05d-0c1855daabc9'
                         type: subgeographic
                     country:
                       data:
-                        id: 12033c9b-71a0-46af-8454-386bc6cdbab7
+                        id: e96b9c8c-3bdd-44c4-bdb0-47f8b54cd6eb
                         type: subgeographic
                     subgeographics:
                       data: []
                     subgeographic_ancestors:
                       data: []
-                - id: 6cb73375-628a-40bb-a98d-944bcf8157be
-                  type: project
-                  attributes:
-                    name: Msgr. Genaro Cronin
-                    description: Placeat commodi libero. Quo recusandae repellat.
-                      Sunt commodi tempore. Voluptatem et corrupti.
-                    recipient_name: Msgr. Genaro Cronin
-                    website: http://bartoletti.com/jeremiah_cronin
-                    leadership_demographics:
-                    - no_specific_focus
-                    - other
-                    leadership_demographics_other: Placeat commodi libero et.
-                    demographics:
-                    - no_specific_focus
-                    - other
-                    demographics_other: Placeat commodi libero et.
-                    recipient_legal_status: for_profit
-                    recipient_legal_status_other: Placeat commodi libero et.
-                    logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TUdFMFlqWXhNaTFqTmpOaExUUm1PVFl0WW1RNVlpMHhZakppTXpFeE9HUTVPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9002ef80f46161a1a690bdb6a11bb2900c9dcade/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TUdFMFlqWXhNaTFqTmpOaExUUm1PVFl0WW1RNVlpMHhZakppTXpFeE9HUTVPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9002ef80f46161a1a690bdb6a11bb2900c9dcade/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt4TUdFMFlqWXhNaTFqTmpOaExUUm1PVFl0WW1RNVlpMHhZakppTXpFeE9HUTVPV1lHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--9002ef80f46161a1a690bdb6a11bb2900c9dcade/picture.jpg
-                  relationships:
-                    state:
+                    investments:
                       data:
-                        id: 8af37a57-1533-4c5c-aa11-b7a9162d312c
-                        type: subgeographic
-                    country:
-                      data:
-                        id: 7d0226d9-773c-4472-a345-cb3452855dac
-                        type: subgeographic
-                    subgeographics:
-                      data: []
-                    subgeographic_ancestors:
-                      data: []
-                - id: bfc43cd6-c0ae-4707-8c66-864d9eecbca0
+                      - id: d53d56eb-fc0a-4e1d-a6dd-e9555d1ea64e
+                        type: investment
+                - id: 1af9cd7e-c4ea-4aa3-891a-d217d5678564
                   type: project
                   attributes:
                     name: Raymon Wisoky
                     description: Et quaerat omnis. Harum voluptas atque. Quo nesciunt
                       voluptas. Suscipit ex cum.
-                    recipient_name: Raymon Wisoky
-                    website: http://hane.com/jules
+                    recipient_name: Otha Kemmer
+                    website: http://kutch-spencer.com/moises
                     leadership_demographics:
-                    - i_dont_know
-                    - no_specific_focus
-                    leadership_demographics_other: Et quaerat omnis veniam.
+                    - hispanic_or_latinx
+                    - other
+                    leadership_demographics_other: Enim repellat pariatur est.
                     demographics:
-                    - i_dont_know
-                    - no_specific_focus
-                    demographics_other: Et quaerat omnis veniam.
-                    recipient_legal_status: cooperative
-                    recipient_legal_status_other: Et quaerat omnis veniam.
+                    - hispanic_or_latinx
+                    - other
+                    demographics_other: Enim repellat pariatur est.
+                    recipient_legal_status: for_profit
+                    recipient_legal_status_other: Enim repellat pariatur est.
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWWpjek1tVXlOQzFoT1RjekxUUmtNVFl0WVRkbE1TMWtOelF5WW1ZMk1qUTFPVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--393b1957f119eb1606b276f6ab8bd9d8d892b0c3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWWpjek1tVXlOQzFoT1RjekxUUmtNVFl0WVRkbE1TMWtOelF5WW1ZMk1qUTFPVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--393b1957f119eb1606b276f6ab8bd9d8d892b0c3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWxrWWpjek1tVXlOQzFoT1RjekxUUmtNVFl0WVRkbE1TMWtOelF5WW1ZMk1qUTFPVEFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--393b1957f119eb1606b276f6ab8bd9d8d892b0c3/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWsxTURnMFptTXhOaTB5TWpVMkxUUTVOemd0WVRkbE1TMHhNbUV4WTJVM056TmhOak1HT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5e6d6d8120cfeee4ef7d79c39d91d7ede04c182d/picture.jpg
                   relationships:
                     state:
                       data:
-                        id: 10d8e978-3655-4712-b23b-521a87a9af25
+                        id: '07388061-e546-4451-a05d-0c1855daabc9'
                         type: subgeographic
                     country:
                       data:
-                        id: b0a1fe5f-22e5-478c-aac9-c2c6967fcb60
+                        id: e96b9c8c-3bdd-44c4-bdb0-47f8b54cd6eb
                         type: subgeographic
                     subgeographics:
                       data: []
                     subgeographic_ancestors:
                       data: []
-                - id: 539ce662-71f6-4c02-a5d4-242e101bf85d
-                  type: project
-                  attributes:
-                    name: Elbert Denesik
-                    description: Dolores fugiat nesciunt. Ut laborum dolores. Sit
-                      neque eos. Expedita molestiae quia.
-                    recipient_name: Elbert Denesik
-                    website: http://hilpert.biz/drusilla
-                    leadership_demographics:
-                    - i_dont_know
-                    - white
-                    leadership_demographics_other: Dolores fugiat nesciunt accusantium.
-                    demographics:
-                    - i_dont_know
-                    - white
-                    demographics_other: Dolores fugiat nesciunt accusantium.
-                    recipient_legal_status: cooperative
-                    recipient_legal_status_other: Dolores fugiat nesciunt accusantium.
-                    logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT1Rsa1l6WTFZeTAyWW1SakxUUmxZamN0T1dNeU5pMDRPREkwTURabVlqZzBNV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f83d7bc8c7deac2dca6a410e662017f09ab3d250/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT1Rsa1l6WTFZeTAyWW1SakxUUmxZamN0T1dNeU5pMDRPREkwTURabVlqZzBNV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f83d7bc8c7deac2dca6a410e662017f09ab3d250/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWswT1Rsa1l6WTFZeTAyWW1SakxUUmxZamN0T1dNeU5pMDRPREkwTURabVlqZzBNV0VHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--f83d7bc8c7deac2dca6a410e662017f09ab3d250/picture.jpg
-                  relationships:
-                    state:
-                      data:
-                        id: a637d84b-b62b-4ca1-92ad-91bd79800dcd
-                        type: subgeographic
-                    country:
-                      data:
-                        id: 92ab0f65-f205-4562-98e2-1f0e36103b25
-                        type: subgeographic
-                    subgeographics:
-                      data:
-                      - id: 3424279f-11c0-4101-97b6-8a9a2120849e
-                        type: subgeographic
-                    subgeographic_ancestors:
-                      data:
-                      - id: 3424279f-11c0-4101-97b6-8a9a2120849e
-                        type: subgeographic
-                      - id: 436be61e-835a-42ae-8269-6b42ee2dbdbd
-                        type: subgeographic
+                    investments:
+                      data: []
+                meta:
+                  page: 1
+                  per_page: 10
+                  from: 1
+                  to: 4
+                  total: 4
+                  pages: 1
+                links:
+                  first: "/api/v1/projects?page%5Bsize%5D=10"
+                  self: "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+                  last: "/api/v1/projects?page%5Bnumber%5D=1&page%5Bsize%5D=10"
               schema:
                 type: object
                 properties:
@@ -1395,6 +1568,12 @@ paths:
                     type: array
                     items:
                       "$ref": "#/components/schemas/project"
+                  meta:
+                    "$ref": "#/components/schemas/pagination_meta"
+                    nullable: true
+                  links:
+                    "$ref": "#/components/schemas/pagination_links"
+                    nullable: true
   "/api/v1/projects/{id}":
     get:
       summary: Returns appropriate project
@@ -1435,7 +1614,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: 44f3cfe6-cde6-4029-ab1e-db9f8fd3f887
+                  id: 1f2e41d4-e541-4608-9b75-cac617d96bbe
                   type: project
                   attributes:
                     name: Otha Kemmer
@@ -1454,28 +1633,30 @@ paths:
                     recipient_legal_status: foundation
                     recipient_legal_status_other: Enim repellat pariatur est.
                     logo:
-                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1NeVl6bGxaQzFsWVRrMUxUUXdPV0l0T1RZNU5TMWlPV0kzTkRKbE1EVmhOamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8499f33cb858890b7b2150e62187edbf80a618f2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
-                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1NeVl6bGxaQzFsWVRrMUxUUXdPV0l0T1RZNU5TMWlPV0kzTkRKbE1EVmhOamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8499f33cb858890b7b2150e62187edbf80a618f2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
-                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3Wm1NeVl6bGxaQzFsWVRrMUxUUXdPV0l0T1RZNU5TMWlPV0kzTkRKbE1EVmhOamtHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--8499f33cb858890b7b2150e62187edbf80a618f2/picture.jpg
+                      small: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TUdNek56RTBNeTFoWXpreExUUTVNR1F0T0dFMk1DMDRObVE0T1RWbU5qSm1aRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--669c44fd40fdac1bd09724d3015e7af44cf12d60/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--8673702c2d856505736727890dcac6a632977811/picture.jpg
+                      medium: http://localhost:4000/sub-path/backend/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TUdNek56RTBNeTFoWXpreExUUTVNR1F0T0dFMk1DMDRObVE0T1RWbU5qSm1aRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--669c44fd40fdac1bd09724d3015e7af44cf12d60/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--e82a96c0eabd93d914de4ef37febd98c36e0e275/picture.jpg
+                      original: http://localhost:4000/sub-path/backend/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3TUdNek56RTBNeTFoWXpreExUUTVNR1F0T0dFMk1DMDRObVE0T1RWbU5qSm1aRFFHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--669c44fd40fdac1bd09724d3015e7af44cf12d60/picture.jpg
                   relationships:
                     state:
                       data:
-                        id: 73b2a961-5a09-4926-964f-3b5fad713422
+                        id: 1aea4a4f-f144-4d1c-937e-f102ec8aaf65
                         type: subgeographic
                     country:
                       data:
-                        id: 5a4e56b1-1947-4201-a762-9bbc4c1abae2
+                        id: 307fd1d3-5f68-4425-b40b-47d9222be2b9
                         type: subgeographic
                     subgeographics:
                       data:
-                      - id: 03da2a68-bedd-4877-8db7-ab67397d7d59
+                      - id: de0a2335-b3f1-4dbe-a0ff-5c8cb2cf8c61
                         type: subgeographic
                     subgeographic_ancestors:
                       data:
-                      - id: 03da2a68-bedd-4877-8db7-ab67397d7d59
+                      - id: c1980913-5b89-4b8b-88c9-6bd491a4a8ad
                         type: subgeographic
-                      - id: 8ccd5448-0e54-41a3-af09-adb6802b7757
+                      - id: de0a2335-b3f1-4dbe-a0ff-5c8cb2cf8c61
                         type: subgeographic
+                    investments:
+                      data: []
               schema:
                 type: object
                 properties:
@@ -1585,35 +1766,35 @@ paths:
             application/json:
               example:
                 data:
-                - id: cffcb705-63e8-4b91-9842-2f0ee2304152
+                - id: fa33b886-5956-451f-9579-f4df60424966
                   type: subgeographic
                   attributes:
                     name: Canada
                     code: BWA
                     geographic: countries
                     abbreviation: C-BWA
-                    created_at: '2022-10-14T15:17:30.101Z'
-                    updated_at: '2022-10-14T15:17:30.101Z'
+                    created_at: '2022-10-17T11:42:27.436Z'
+                    updated_at: '2022-10-17T11:42:27.436Z'
                   relationships:
                     parent:
                       data:
                     subgeographics:
                       data:
-                      - id: f050e77e-38a2-4bfd-9941-b1604d58bd7e
+                      - id: 53aca656-d724-43ac-91d8-e7c15568938f
                         type: subgeographic
-                - id: f050e77e-38a2-4bfd-9941-b1604d58bd7e
+                - id: 53aca656-d724-43ac-91d8-e7c15568938f
                   type: subgeographic
                   attributes:
                     name: Papua New Guinea
                     code: NPL
                     geographic: regions
                     abbreviation: R-NPL
-                    created_at: '2022-10-14T15:17:30.118Z'
-                    updated_at: '2022-10-14T15:17:30.118Z'
+                    created_at: '2022-10-17T11:42:27.472Z'
+                    updated_at: '2022-10-17T11:42:27.472Z'
                   relationships:
                     parent:
                       data:
-                        id: cffcb705-63e8-4b91-9842-2f0ee2304152
+                        id: fa33b886-5956-451f-9579-f4df60424966
                         type: subgeographic
                     subgeographics:
                       data: []
@@ -1659,11 +1840,11 @@ paths:
                       - - 0
                         - 0
                   properties:
-                    id: 8b03be18-8af0-4ae0-8043-f7799ce28b31
+                    id: 545a7d31-bcad-4358-b281-889387251345
                     code: NPL
                     name: Papua New Guinea
                     abbreviation: R-NPL
-                    parent_id: 48f94d9d-8a54-4660-9bfd-c1e5e3de3251
+                    parent_id: 2db0435b-951f-43a7-ab9e-791b9b2b3840
                 - type: Feature
                   geometry:
                     type: Polygon
@@ -1679,11 +1860,11 @@ paths:
                       - - 0
                         - 0
                   properties:
-                    id: 12dd9778-a304-42bf-9859-87c26d65cda2
+                    id: 6102bfe1-7235-48bf-a735-e881781959fb
                     code: IRL
                     name: Jamaica
                     abbreviation: R-IRL
-                    parent_id: 48f94d9d-8a54-4660-9bfd-c1e5e3de3251
+                    parent_id: 2db0435b-951f-43a7-ab9e-791b9b2b3840
               schema:
                 "$ref": "#/components/schemas/subgeographic_geojson"
         '422':
@@ -1918,6 +2099,8 @@ components:
               "$ref": "#/components/schemas/response_relations"
             subgeographic_ancestors:
               "$ref": "#/components/schemas/response_relations"
+            investments:
+              "$ref": "#/components/schemas/response_relations"
       required:
       - id
       - type
@@ -2006,6 +2189,8 @@ components:
             subgeographics:
               "$ref": "#/components/schemas/response_relations"
             subgeographic_ancestors:
+              "$ref": "#/components/schemas/response_relations"
+            investments:
               "$ref": "#/components/schemas/response_relations"
       required:
       - id


### PR DESCRIPTION
This PR finalises Projects API endpoint and adds:
 - geographic filter
 - subgeographics filter
 - enum filters (areas, recipient_legal_statuses, demographics)
 - pagination and possibility to turn it off
 - full text searching
 - sorting by name and funders_count

It also adds has_many relation for Investments to Project and Funder API so they can be loaded via it.

https://vizzuality.atlassian.net/browse/FORA-187
https://vizzuality.atlassian.net/browse/FORA-188
https://vizzuality.atlassian.net/browse/FORA-189
https://vizzuality.atlassian.net/browse/FORA-190