### PR TITLE
feat: Admin model and login screen for Backoffice

### DIFF
--- a/.github/workflows/backend_ci_cd.yml
+++ b/.github/workflows/backend_ci_cd.yml
@@ -47,6 +47,19 @@ jobs:
           bundler-cache: true
           working-directory: backend
 
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('yarn.lock') }}
+          working-directory: backend
+          
+      - name: Install Node Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: backend
+        run: yarn install --frozen-lockfile
+
       - name: Setup database
         working-directory: backend
         run: |

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -13,6 +13,7 @@ gem "rswag"
 gem "rspec-rails", "6.0.0.rc1"
 gem "cancancan"
 gem "redis"
+gem "devise"
 
 gem "dotenv-rails"
 
@@ -22,6 +23,8 @@ gem "jsbundling-rails"
 gem "sprockets-rails"
 gem "stimulus-rails"
 gem "turbo-rails"
+gem "simple_form"
+gem "simple_form-tailwind"
 
 # API
 gem "jsonapi-serializer"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -237,9 +237,9 @@ GEM
       timeout
     net-ssh (7.0.1)
     nio4r (2.5.8)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     optimist (3.0.1)
     orm_adapter (0.5.0)

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
+    bcrypt (3.1.18)
     bcrypt_pbkdf (1.1.0)
     bindex (0.8.1)
     bootsnap (1.13.0)
@@ -159,6 +160,12 @@ GEM
     debug (1.6.2)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
+    devise (4.8.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
     diff-lcs (1.5.0)
     digest (3.1.0)
     docile (1.4.0)
@@ -235,6 +242,7 @@ GEM
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     optimist (3.0.1)
+    orm_adapter (0.5.0)
     pagy (5.10.1)
       activesupport
     parallel (1.22.1)
@@ -288,6 +296,9 @@ GEM
     regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rexml (3.2.5)
     rgeo (2.4.0)
     rgeo-activerecord (7.0.1)
@@ -355,6 +366,12 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.5.0)
+    simple_form (5.1.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
+    simple_form-tailwind (0.1.1)
+      railties (>= 4.0)
+      simple_form (>= 5.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -395,6 +412,8 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -439,6 +458,7 @@ DEPENDENCIES
   closure_tree
   cuprite
   debug
+  devise
   dotenv-rails
   ed25519
   factory_bot_rails
@@ -463,6 +483,8 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   sidekiq
+  simple_form
+  simple_form-tailwind
   simplecov
   sprockets-rails
   standard

--- a/backend/app/assets/stylesheets/application.tailwind.css
+++ b/backend/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .button {
+    @apply relative flex items-center justify-center font-semibold rounded-lg border px-10 py-3
+  }
+
+  .button-primary-green {
+    @apply text-grey-0 border-green-40 hover:bg-green-60 active:bg-grey-0/10 text-base transition-colors bg-green-40
+  }
+}

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  protected
+
+  def after_sign_out_path_for(resource_or_scope)
+    scope = Devise::Mapping.find_scope!(resource_or_scope)
+    if scope == :admin
+      new_admin_session_path
+    else
+      super
+    end
+  end
 end

--- a/backend/app/controllers/backoffice/admins_controller.rb
+++ b/backend/app/controllers/backoffice/admins_controller.rb
@@ -1,0 +1,7 @@
+module Backoffice
+  class AdminsController < BaseController
+    def index
+      # TODO
+    end
+  end
+end

--- a/backend/app/controllers/backoffice/base_controller.rb
+++ b/backend/app/controllers/backoffice/base_controller.rb
@@ -1,0 +1,13 @@
+module Backoffice
+  class BaseController < ApplicationController
+    include Pagy::Backend
+
+    layout "backoffice"
+
+    before_action :authenticate_admin!
+
+    def pagy_defaults
+      {items: 10}
+    end
+  end
+end

--- a/backend/app/models/admin.rb
+++ b/backend/app/models/admin.rb
@@ -1,0 +1,16 @@
+class Admin < ApplicationRecord
+  devise :database_authenticatable, :registerable, :rememberable, :validatable
+
+  validates :password, length: {minimum: 12, message: :password_length}, allow_nil: true
+  validate :password_complexity
+  validates_presence_of :first_name, :last_name
+
+  private
+
+  def password_complexity
+    return if password.blank?
+    return if password.match?(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)./)
+
+    errors.add :password, :password_complexity
+  end
+end

--- a/backend/app/views/admins/sessions/new.html.erb
+++ b/backend/app/views/admins/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<div class="bg-white p-6 rounded-2xl shadow-lg min-w-[600px]">
+  <h2 class="text-grey-0 font-bold text-lg"><%= t("backoffice.sign_in.welcome") %></h2>
+
+  <p class="my-6 text-grey-20"><%= t("backoffice.sign_in.enter_details_below") %></p>
+
+  <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: {"data-turbo": false}) do |f| %>
+    <% flash.each do |type, message| %>
+      <div class="mb-4 bg-red-50 text-black text-sm px-4 py-4">
+        <%= message %>
+      </div>
+    <% end %>
+
+    <%= f.input :email, required: true %>
+    <%= f.input :password, required: true %>
+
+    <div class="flex">
+      <div class="grow">
+        <% if devise_mapping.rememberable? %>
+          <%= f.input :remember_me, as: :boolean %>
+        <% end%>
+      </div>
+    </div>
+
+    <%= f.submit t("backoffice.sign_in.sign_in"), class: "button button-primary-green mx-auto" %>
+  <% end %>
+</div>

--- a/backend/app/views/backoffice/admins/index.html.erb
+++ b/backend/app/views/backoffice/admins/index.html.erb
@@ -1,0 +1,1 @@
+WELCOME!!

--- a/backend/app/views/layouts/application.html.erb
+++ b/backend/app/views/layouts/application.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Backend</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  </head>
+
+  <body>
+    <%= content_for?(:content) ? yield(:content) : yield %>
+  </body>
+</html>

--- a/backend/app/views/layouts/backoffice.html.erb
+++ b/backend/app/views/layouts/backoffice.html.erb
@@ -1,0 +1,22 @@
+<% content_for :content do %>
+  <header class="w-full bg-green-0 text-black">
+    <div class="container mx-auto">
+      <div class="flex items-center justify-between h-16 md:h-20 gap-x-8 md:gap-x-16">
+        <div>
+          <a class="font-semibold" href="/">FORA</a>
+          <span class="font-light"><%= t("backoffice.layout.header") %></span>
+        </div>
+        <div class="flex items-center justify-end flex-1 gap-2">
+          <%= current_admin.email %>
+          <%= button_to t("backoffice.layout.sign_out"), destroy_admin_session_path, data: {turbo: false}, method: :delete %>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="container mx-auto py-6 mt-1 relative table">
+    <%= yield %>
+  </main>
+<% end %>
+
+<%= render template: "layouts/application" %>

--- a/backend/app/views/layouts/devise.html.erb
+++ b/backend/app/views/layouts/devise.html.erb
@@ -1,0 +1,25 @@
+<% content_for :content do %>
+  <header class="fixed top-0 w-full h-16 lg:h-20 z-10 py-4 bg-green-0">
+    <div class="flex items-center">
+      <div class="container mx-auto">
+        <a class="font-semibold" href="/">FORA</a>
+        <span class="font-light">Backoffice</span>
+      </div>
+    </div>
+  </header>
+
+  <div class="bg-green-0 absolute min-h-[60vh] w-full z-[-1]">
+  </div>
+
+  <main class="flex w-full">
+    <div class="min-h-screen container mx-auto flex flex-col">
+      <div class="mx-auto table h-full">
+        <div class="table-cell align-middle">
+          <%= yield %>
+        </div>
+      </div>
+    </div>
+  </main>
+<% end %>
+
+<%= render template: "layouts/application" %>

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '01965ae193fa69a5f1b9f9e549244844c7dea5db9189ee50ec6af47cc8cee485cc40db1961889113627b5c3accd3a9ba08f6a0a98a1abf3b660b1b0c85017c90'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = ENV.fetch("MAILER_DEFAULT_FROM", "please-change-me@example.com")
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require "devise/orm/active_record"
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'a85c2e01e6c50fbcc04893f7ee8a80be2d35907b02da4341ee83822834c609fc5d2647a4800de5546247347c6af1b1b815934581945fde64931ab28393d81f6d'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  config.scoped_views = true
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Turbolinks configuration
+  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
+  #
+  # ActiveSupport.on_load(:devise_failure_app) do
+  #   include Turbolinks::Controller
+  # end
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/backend/config/initializers/simple_form.rb
+++ b/backend/config/initializers/simple_form.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/heartcombo/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+    hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint, wrap_with: {tag: :span, class: :hint}
+    b.use :error, wrap_with: {tag: :span, class: :error}
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = "btn"
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = "error_notification"
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = "checkbox"
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/backend/config/initializers/simple_form_tailwind.rb
+++ b/backend/config/initializers/simple_form_tailwind.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Default class for buttons
+  config.button_class = "button button-primary-green"
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = ""
+
+  # How the label text should be generated altogether with the required text.
+  config.label_text = lambda { |label, required, explicit_label| "#{label} #{required}" }
+
+  # Define the way to render check boxes / radio buttons with labels.
+  config.boolean_style = :inline
+
+  # You can wrap each item in a collection of radio/check boxes with a tag
+  config.item_wrapper_tag = :div
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  config.include_default_input_wrapper_class = false
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = "text-black text-sm px-6 py-4 border-0 rounded relative my-4 bg-red-50"
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # :to_sentence to list all errors for each field.
+  config.error_method = :to_sentence
+
+  # add validation classes to `input_field`
+  config.input_field_error_class = "border-red-50"
+  config.input_field_valid_class = "border-green-20"
+  config.label_class = "font-sans text-black font-semibold text-sm mb-2"
+
+  checkbox_class = "appearance-none inline-block w-4 h-4 mr-2 mt-0.5 px-0.5 py-[3px] border border-black rounded hover:border hover:border-green-0 outline-none focus-visible:ring-green-0 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white checked:border-green-0 checked:bg-green-0 checked:bg-checkbox-checked bg-no-repeat bg-center disabled:opacity-60 disabled:hover:border-black transition"
+
+  # vertical forms
+  #
+  # vertical default_wrapper
+  config.wrappers :vertical_form, tag: "div", class: "mb-4" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: "block", error_class: "text-red-50"
+    b.use :input, class: "block w-full px-4 py-2 text-base text-black placeholder-grey-20 placeholder-opacity-100 border border-solid border-black hover:shadow-sm focus:shadow-sm focus:border-green-0 outline-none bg-white rounded-lg disabled:opacity-60 transition", error_class: "invalid:border-red-50", valid_class: "border-green-40"
+    b.use :full_error, wrap_with: {tag: "p", class: "mt-2 text-red-50 text-xs italic"}
+    b.use :hint, wrap_with: {tag: "p", class: "mt-2 text-black text-xs italic"}
+  end
+
+  # vertical input for boolean (aka checkboxes)
+  config.wrappers :vertical_boolean, tag: "div", class: "mb-4 flex items-start", error_class: "" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper tag: "div", class: "flex items-center h-5" do |ba|
+      ba.use :input, class: checkbox_class
+    end
+    b.wrapper tag: "div", class: "ml-3 text-sm" do |bb|
+      bb.use :label, class: "block", error_class: "text-red-50"
+      bb.use :hint, wrap_with: {tag: "p", class: "block text-black text-xs italic"}
+      bb.use :full_error, wrap_with: {tag: "p", class: "block text-red-50 text-xs italic"}
+    end
+  end
+
+  # vertical input for radio buttons and check boxes
+  config.wrappers :horizontal_collection, item_wrapper_class: "flex items-center", item_label_class: "font-sans text-black text-base", tag: "div", class: "my-4" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: "legend", class: "font-sans text-black font-semibold text-sm", error_class: "text-red-50" do |ba|
+      ba.use :label_text
+    end
+    b.wrapper tag: "div", class: "flex flex-wrap gap-4.5 mt-2" do |bb|
+      bb.use :input,
+        class: checkbox_class,
+        error_class: "invalid:border-red-50",
+        valid_class: "text-green-40"
+      bb.use :full_error, wrap_with: {tag: "p", class: "block mt-2 text-red-50 text-xs italic"}
+      bb.use :hint, wrap_with: {tag: "p", class: "mt-2 text-black text-xs italic"}
+    end
+  end
+
+  # vertical file input
+  config.wrappers :vertical_file, tag: "div", class: "mb-4" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label, class: "font-sans text-black font-semibold text-sm", error_class: "text-red-50"
+    b.use :input, class: "w-full text-black px-3 py-2 border rounded", error_class: "text-red-50 border-red-50", valid_class: "text-green-40"
+    b.use :full_error, wrap_with: {tag: "p", class: "mt-2 text-red-50 text-xs italic"}
+    b.use :hint, wrap_with: {tag: "p", class: "mt-2 text-black text-xs italic"}
+  end
+
+  # vertical multi select
+  config.wrappers :vertical_multi_select, tag: "div", class: "my-4", error_class: "f", valid_class: "" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: "legend", class: "font-sans text-black font-semibold text-sm", error_class: "text-red-50" do |ba|
+      ba.use :label_text
+    end
+    b.wrapper tag: "div", class: "inline-flex space-x-1" do |ba|
+      ba.use :input, class: "flex w-auto w-auto shadow appearance-none border border-black rounded w-full p-2 bg-white focus:outline-none focus:border-blue-40 text-grey-60 leading-4 transition-colors duration-200 ease-in-out"
+    end
+    b.use :full_error, wrap_with: {tag: "p", class: "mt-2 text-red-50 text-xs italic"}
+    b.use :hint, wrap_with: {tag: "p", class: "mt-2 text-black text-xs italic"}
+  end
+
+  # vertical range input
+  config.wrappers :vertical_range, tag: "div", class: "my-4", error_class: "text-red-50", valid_class: "text-green-40" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label, class: "text-sm font-medium text-black block", error_class: "text-red-50"
+    b.wrapper tag: "div", class: "flex items-center h-5" do |ba|
+      ba.use :input, class: "rounded-lg overflow-hidden appearance-none bg-black h-3 w-full text-grey-20", error_class: "text-red-50", valid_class: "text-green-40"
+    end
+    b.use :full_error, wrap_with: {tag: "p", class: "mt-2 text-red-50 text-xs italic"}
+    b.use :hint, wrap_with: {tag: "p", class: "mt-2 text-black text-xs italic"}
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :vertical_form
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  config.wrapper_mappings = {
+    boolean: :vertical_boolean,
+    check_boxes: :horizontal_collection,
+    date: :vertical_multi_select,
+    datetime: :vertical_multi_select,
+    file: :vertical_file,
+    radio_buttons: :horizontal_collection,
+    range: :vertical_range,
+    time: :vertical_multi_select
+  }
+end

--- a/backend/config/locales/devise.en.yml
+++ b/backend/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -1,9 +1,25 @@
 en:
   "true": "yes"
   "false": "no"
+  activerecord:
+    errors:
+      models:
+        admin:
+          attributes:
+            password:
+              password_length: must be at least %{count} characters long
+              password_complexity: must include at least one lowercase letter, one uppercase letter, and one digit
   api:
     errors:
       missing_geographic: "Geographic param is mandatory!"
+  backoffice:
+    layout:
+      header: Backoffice
+      sign_out: Sign out
+    sign_in:
+      welcome: Welcome to FORA backoffice.
+      enter_details_below: Please enter your details below.
+      sign_in: Sign in
   enums:
     area:
       equity_and_justice:

--- a/backend/config/routes/backoffice.rb
+++ b/backend/config/routes/backoffice.rb
@@ -1,0 +1,8 @@
+devise_for :admins, path: "backoffice"
+
+# admin_root_path is useful for devise
+get "/backoffice", to: redirect("backoffice/admins"), as: :admin_root
+
+namespace :backoffice do
+  resources :admins
+end

--- a/backend/config/tailwind.config.js
+++ b/backend/config/tailwind.config.js
@@ -1,10 +1,125 @@
+const colors = require('tailwindcss/colors');
+
 module.exports = {
   content: [
     './app/views/**/*',
     './app/helpers/**/*.rb',
+    './config/initializers/simple_form_tailwind.rb',
     './app/javascript/**/*.js'
   ],
-  theme: {
-  },
   plugins: [],
+  theme: {
+    fontFamily: {
+      sans: ['Open\\ Sans', 'sans'],
+      display: ['Montserrat', 'display'],
+    },
+    fontSize: {
+      xxs: [
+        '0.5rem',
+        {
+          lineHeight: '0.75rem',
+        },
+      ],
+      xs: [
+        '0.6875rem',
+        {
+          lineHeight: '0.75rem',
+        },
+      ],
+      sm: [
+        '0.75rem',
+        {
+          lineHeight: '1rem',
+        },
+      ],
+      base: [
+        '0.875rem',
+        {
+          lineHeight: '1.1875rem',
+        },
+      ],
+      lg: [
+        '1rem',
+        {
+          lineHeight: '1.5rem',
+        },
+      ],
+      xl: [
+        '1.125rem',
+        {
+          lineHeight: '1.75rem',
+        },
+      ],
+      '2xl': [
+        '1.5rem',
+        {
+          lineHeight: '2rem',
+        },
+      ],
+      '3xl': [
+        '2.5rem',
+        {
+          lineHeight: '3rem',
+        },
+      ],
+      '4xl': [
+        '3.25rem',
+        {
+          lineHeight: '3.25rem',
+        },
+      ],
+      '5xl': [
+        '4rem',
+        {
+          lineHeight: '4.25rem',
+        },
+      ],
+      '6xl': [
+        '5rem',
+        {
+          lineHeight: '5.625rem',
+        },
+      ],
+    },
+    colors: {
+      transparent: 'transparent',
+      current: 'currentColor',
+      black: '#000000',
+      white: '#FFFFFF',
+      green: {
+        0: '#A3BC3B',
+        20: '#B5C962',
+        40: '#C8D789',
+        60: '#DAE4B1',
+        80: '#E3EBC4',
+        100: '#EDF2D8',
+      },
+      yellow: {
+        0: '#D8BE27',
+        20: '#E0CB52',
+        40: '#E8D87D',
+        60: '#EFE5A9',
+        80: '#F3ECBE',
+        100: '#F7F2D4',
+      },
+      blue: {
+        0: '#00548E',
+        20: '#2570A5',
+        40: '#498DBB',
+        60: '#6EA9D2',
+        80: '#92C6E8',
+        100: '#B7E2FF',
+      },
+      grey: {
+        0: '#1B1B1B',
+        20: '#707070',
+        40: '#CDCDCD',
+        60: '#F8F8F8',
+      },
+      red: {
+        ...colors.red,
+        0: '#CC503E',
+      },
+    },
+  },
 }

--- a/backend/db/migrate/20221018084105_devise_create_admins.rb
+++ b/backend/db/migrate/20221018084105_devise_create_admins.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class DeviseCreateAdmins < ActiveRecord::Migration[7.0]
+  def change
+    create_table :admins, id: :uuid do |t|
+      ## Database authenticatable
+      t.string :email, null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      # t.string   :reset_password_token
+      # t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :admins, :email, unique: true
+    # add_index :admins, :reset_password_token, unique: true
+    # add_index :admins, :confirmation_token,   unique: true
+    # add_index :admins, :unlock_token,         unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_12_071532) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_18_084105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -41,6 +41,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_12_071532) do
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "admins", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "remember_created_at"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
   end
 
   create_table "funder_subgeographics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -7,6 +7,9 @@ if Rails.env.development?
   Funder.delete_all
   Project.delete_all
   Recipient.delete_all
+  Admin.delete_all
+
+  Admin.create! first_name: "Admin", last_name: "Example", password: "SuperSecret1234", email: "admin@example.com"
 
   Rake::Task["subgeographics:import"].invoke
 

--- a/backend/spec/factories/admins.rb
+++ b/backend/spec/factories/admins.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :admin do
+    sequence(:first_name) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Name.first_name
+    end
+    sequence(:last_name) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Name.last_name
+    end
+    sequence(:email) { |n| "admin#{n}@example.com" }
+    password { "SuperSecret1234" }
+  end
+end

--- a/backend/spec/models/admin_spec.rb
+++ b/backend/spec/models/admin_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Admin, type: :model do
+  subject { build(:admin) }
+
+  it { is_expected.to be_valid }
+
+  it "should be invalid without email" do
+    subject.email = nil
+    expect(subject).to have(1).errors_on(:email)
+  end
+
+  it "should be invalid with invalid email" do
+    subject.email = "invalidemail"
+    expect(subject).to have(1).errors_on(:email)
+  end
+
+  it "should be invalid without first name" do
+    subject.first_name = nil
+    expect(subject).to have(1).errors_on(:first_name)
+  end
+
+  it "should be invalid without last name" do
+    subject.last_name = nil
+    expect(subject).to have(1).errors_on(:last_name)
+  end
+
+  it "should be invalid with short password" do
+    subject.password = "secret"
+    expect(subject.errors_on(:password)).to include(I18n.t("activerecord.errors.models.admin.attributes.password.password_length", count: 12))
+  end
+
+  it "should be invalid with too simple password" do
+    subject.password = "verysimplepassword"
+    expect(subject.errors_on(:password)).to include(I18n.t("activerecord.errors.models.admin.attributes.password.password_complexity"))
+  end
+end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -30,6 +30,9 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include Rails.application.routes.url_helpers, type: :request
   config.include RequestHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Warden::Test::Helpers
 
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/backend/spec/system/backoffice/auth_spec.rb
+++ b/backend/spec/system/backoffice/auth_spec.rb
@@ -1,0 +1,43 @@
+require "system_helper"
+
+RSpec.describe "Backoffice: Auth", type: :system do
+  let_it_be(:admin) { create(:admin, email: "admin@example.com", password: "SuperSecret6", first_name: "Admin", last_name: "Example") }
+
+  describe "Login" do
+    before { visit "/backoffice" }
+
+    it "authenticate user successfully" do
+      fill_in :admin_email, with: "admin@example.com"
+      fill_in :admin_password, with: "SuperSecret6"
+
+      click_on t("backoffice.sign_in.sign_in")
+
+      expect(page).to have_text(t("backoffice.layout.sign_out"))
+    end
+
+    context "when wrong credentials" do
+      it "shows error message" do
+        fill_in :admin_email, with: "admin@example.com"
+        fill_in :admin_password, with: "secret3"
+
+        click_on t("backoffice.sign_in.sign_in")
+
+        expect(page).to have_text(t("devise.failure.invalid", authentication_keys: "Email"))
+      end
+    end
+  end
+
+  describe "Log out" do
+    before { sign_in admin }
+
+    it "works well" do
+      visit "/backoffice"
+      expect(page).to have_text(t("backoffice.layout.sign_out"))
+
+      click_on t("backoffice.layout.sign_out")
+
+      expect(page).to have_text(t("devise.sessions.signed_out"))
+      expect(page).to have_current_path(new_admin_session_path)
+    end
+  end
+end


### PR DESCRIPTION
PR adds `Admin` model and initial login screen for Backoffice which uses Devise to auth users.

I have tried to copy&paste as much logic as possible from HeCo project --> there is no design for FORA backoffice so I have just taken tailwind config from FE and original design of HeCo and merged these two together (basically changed couple styles and mainly color palete).

![Screenshot 2022-10-19 at 11 42 50](https://user-images.githubusercontent.com/20660167/196659904-23972297-e7a6-420c-b756-1fd7213189ba.png)

By the way @agnessa , I am not sure (was not able to find it) how deployment handles assets and if they get compiled during deployment. It is something which we didn't need to take care of till now, but it is required for this PR to work.

https://vizzuality.atlassian.net/browse/FORA-192
https://vizzuality.atlassian.net/browse/FORA-193
https://vizzuality.atlassian.net/browse/FORA-194