### PR TITLE
Fix errors with images

### DIFF
--- a/backend/config/initializers/active_storage.rb
+++ b/backend/config/initializers/active_storage.rb
@@ -1,0 +1,1 @@
+Rails.application.config.active_storage.variant_processor = :mini_magick

--- a/infrastructure/templates/server_setup.sh.tpl
+++ b/infrastructure/templates/server_setup.sh.tpl
@@ -58,6 +58,8 @@ sudo apt-get install -y libnginx-mod-http-passenger
 
 if [ ! -f /etc/nginx/modules-enabled/50-mod-http-passenger.conf ]; then sudo ln -s /usr/share/nginx/modules-available/mod-http-passenger.load /etc/nginx/modules-enabled/50-mod-http-passenger.conf ; fi
 
+# Install imagemagick
+sudo apt-get install -y imagemagick
 
 #
 # Create project dir


### PR DESCRIPTION
Originally the error was about missing vips libraries; however, after installing missing libraries the error got even weirder, so I decided to use imagemagick instead, and since vips is default in Rails 7 I added an initialiser, exactly like we do in HeCo. System libs already installed on the server.