### PR TITLE
refactoring: Widgets respects Investments privacy attribute

### DIFF
--- a/backend/app/models/investment.rb
+++ b/backend/app/models/investment.rb
@@ -17,4 +17,7 @@ class Investment < ApplicationRecord
   validates :funding_type, presence: true, if: -> { capital_type == "grants" }
   validates :year_invested, :initial_funded_year, numericality: {only_integer: true, greater_than: 1980, less_than: 2100}
   validates :amount, numericality: {greater_than: 0}
+
+  scope :can_show_aggregated_amount, -> { where privacy: %w[all aggregate_amount_funded] }
+  scope :can_be_shown_without_amount, -> { where privacy: %w[all aggregate_amount_funded amount_funded_visible_only_to_members amount_funded_visible_only_to_staff] }
 end

--- a/backend/app/services/widgets/queries/funded_areas.rb
+++ b/backend/app/services/widgets/queries/funded_areas.rb
@@ -20,7 +20,8 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.select(:amount, :areas).where(year_invested: year).each_with_object({}) do |investment, res|
+        @investments ||= Investment.can_show_aggregated_amount.select(:amount, :areas).where(year_invested: year)
+          .each_with_object({}) do |investment, res|
           investment.areas.each do |investment_area|
             res[investment_area] = (res[investment_area] || 0) + (investment.amount / investment.areas.size).round
           end

--- a/backend/app/services/widgets/queries/funded_capital_types.rb
+++ b/backend/app/services/widgets/queries/funded_capital_types.rb
@@ -20,7 +20,7 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.where(year_invested: year).group("capital_type").sum(:amount)
+        @investments ||= Investment.can_show_aggregated_amount.where(year_invested: year).group("capital_type").sum(:amount)
       end
     end
   end

--- a/backend/app/services/widgets/queries/funded_demographics.rb
+++ b/backend/app/services/widgets/queries/funded_demographics.rb
@@ -20,7 +20,7 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.select(:amount, :demographics).where(year_invested: year)
+        @investments ||= Investment.can_show_aggregated_amount.select(:amount, :demographics).where(year_invested: year)
           .each_with_object({}) do |investment, res|
           investment.demographics.each do |demographic|
             res[demographic] = (res[demographic] || 0) + (investment.amount / investment.demographics.size).round

--- a/backend/app/services/widgets/queries/funded_funder_types.rb
+++ b/backend/app/services/widgets/queries/funded_funder_types.rb
@@ -20,7 +20,8 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.where(year_invested: year).joins(:funder).group("funders.funder_type").sum(:amount)
+        @investments ||= Investment.can_show_aggregated_amount.where(year_invested: year).joins(:funder)
+          .group("funders.funder_type").sum(:amount)
       end
     end
   end

--- a/backend/app/services/widgets/queries/funded_recipient_legal_statuses.rb
+++ b/backend/app/services/widgets/queries/funded_recipient_legal_statuses.rb
@@ -20,7 +20,8 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.where(year_invested: year).joins(project: :recipient).group("recipients.recipient_legal_status").sum(:amount)
+        @investments ||= Investment.can_show_aggregated_amount.where(year_invested: year).joins(project: :recipient)
+          .group("recipients.recipient_legal_status").sum(:amount)
       end
     end
   end

--- a/backend/app/services/widgets/queries/funded_subgeographics.rb
+++ b/backend/app/services/widgets/queries/funded_subgeographics.rb
@@ -35,7 +35,7 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.select(:id, :amount).includes(:subgeographic_ancestors)
+        @investments ||= Investment.can_show_aggregated_amount.select(:id, :amount).includes(:subgeographic_ancestors)
           .joins(:subgeographic_ancestors).where(year_invested: year, subgeographics: {geographic: geographic})
           .each_with_object({}) do |investment, res|
           subgeographics = investment.subgeographic_ancestors.to_a.select { |s| s.geographic == geographic }

--- a/backend/app/services/widgets/queries/summary.rb
+++ b/backend/app/services/widgets/queries/summary.rb
@@ -15,9 +15,9 @@ module Widgets
       def values
         [[
           {value: Funder.where(date_joined_fora: ..DateTime.new(year).end_of_year).count.to_f},
-          {value: Investment.where(year_invested: year).count("DISTINCT investments.project_id").to_f},
-          {value: Investment.where(year_invested: year).sum(:amount).to_f},
-          {value: Investment.where(year_invested: year).where(capital_type: %w[grants re_grants]).sum(:amount).to_f}
+          {value: Investment.can_be_shown_without_amount.where(year_invested: year).count("DISTINCT investments.project_id").to_f},
+          {value: Investment.can_show_aggregated_amount.where(year_invested: year).sum(:amount).to_f},
+          {value: Investment.can_show_aggregated_amount.where(year_invested: year).where(capital_type: %w[grants re_grants]).sum(:amount).to_f}
         ]]
       end
     end

--- a/backend/app/services/widgets/queries/total_funders_capital_types.rb
+++ b/backend/app/services/widgets/queries/total_funders_capital_types.rb
@@ -20,7 +20,8 @@ module Widgets
       end
 
       def investments
-        @investments = Investment.where(year_invested: year).group("capital_type").count("DISTINCT investments.funder_id")
+        @investments = Investment.can_be_shown_without_amount.where(year_invested: year)
+          .group("capital_type").count("DISTINCT investments.funder_id")
       end
     end
   end

--- a/backend/app/services/widgets/queries/total_funders_demographics.rb
+++ b/backend/app/services/widgets/queries/total_funders_demographics.rb
@@ -20,7 +20,7 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.joins(:funder).where(funders: {date_joined_fora: ..DateTime.new(year).end_of_year})
+        @investments ||= Investment.can_be_shown_without_amount.joins(:funder).where(funders: {date_joined_fora: ..DateTime.new(year).end_of_year})
           .group("unnest(investments.demographics)").count("DISTINCT investments.funder_id")
       end
     end

--- a/backend/app/services/widgets/queries/total_projects_capital_types.rb
+++ b/backend/app/services/widgets/queries/total_projects_capital_types.rb
@@ -20,7 +20,8 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.where(year_invested: year).group("capital_type").count("DISTINCT investments.project_id")
+        @investments ||= Investment.can_be_shown_without_amount.where(year_invested: year)
+          .group("capital_type").count("DISTINCT investments.project_id")
       end
     end
   end

--- a/backend/app/services/widgets/queries/total_projects_demographics.rb
+++ b/backend/app/services/widgets/queries/total_projects_demographics.rb
@@ -20,7 +20,7 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.where(year_invested: year).group("unnest(demographics)")
+        @investments ||= Investment.can_be_shown_without_amount.where(year_invested: year).group("unnest(demographics)")
           .count("DISTINCT investments.project_id")
       end
     end

--- a/backend/app/services/widgets/queries/total_projects_funders_areas.rb
+++ b/backend/app/services/widgets/queries/total_projects_funders_areas.rb
@@ -22,7 +22,8 @@ module Widgets
       end
 
       def total_projects
-        @total_projects ||= Investment.where(year_invested: year).group("unnest(areas)").count("DISTINCT investments.project_id")
+        @total_projects ||= Investment.can_be_shown_without_amount.where(year_invested: year)
+          .group("unnest(areas)").count("DISTINCT investments.project_id")
       end
 
       def total_funders

--- a/backend/app/services/widgets/queries/total_projects_funders_subgeographics.rb
+++ b/backend/app/services/widgets/queries/total_projects_funders_subgeographics.rb
@@ -37,7 +37,7 @@ module Widgets
       end
 
       def total_projects
-        @total_projects ||= Investment.where(year_invested: 2021).joins(:subgeographic_ancestors)
+        @total_projects ||= Investment.can_be_shown_without_amount.where(year_invested: 2021).joins(:subgeographic_ancestors)
           .group("ancestor_id").count("DISTINCT investments.project_id")
       end
 

--- a/backend/app/services/widgets/queries/total_projects_recipient_legal_statuses.rb
+++ b/backend/app/services/widgets/queries/total_projects_recipient_legal_statuses.rb
@@ -20,7 +20,8 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.where(year_invested: year).joins(project: :recipient).group("recipients.recipient_legal_status").count
+        @investments ||= Investment.can_be_shown_without_amount.where(year_invested: year).joins(project: :recipient)
+          .group("recipients.recipient_legal_status").count
       end
     end
   end

--- a/backend/spec/requests/api/v1/widgets_spec.rb
+++ b/backend/spec/requests/api/v1/widgets_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "API V1 Widgets", type: :request do
       parameter name: "filter[demographics]", in: :query, type: :string, enum: Demographic::TYPES, description: "Filter results only for specified demographics. Use comma to separate multiple fields", required: false
 
       let!(:widget) { create :widget, report_pages: ["general_report"], report_year: 2021, slug: "summary", widget_type: "total" }
-      let!(:investment) { create :investment, year_invested: 2021 }
+      let!(:investment) { create :investment, privacy: "all", year_invested: 2021 }
       let(:slug) { widget.slug }
       let("filter[report_year]") { 2021 }
 
@@ -127,7 +127,7 @@ RSpec.describe "API V1 Widgets", type: :request do
       parameter name: "filter[demographics]", in: :query, type: :string, enum: Demographic::TYPES, description: "Filter results only for specified demographics. Use comma to separate multiple fields", required: false
 
       let!(:widget) { create :widget, report_pages: ["general_report"], report_year: 2021, slug: "summary", widget_type: "total" }
-      let!(:investment) { create :investment, year_invested: 2021 }
+      let!(:investment) { create :investment, privacy: "all", year_invested: 2021 }
       let(:slug) { widget.slug }
       let("filter[report_year]") { 2021 }
 

--- a/backend/spec/services/widgets/queries/funded_areas_spec.rb
+++ b/backend/spec/services/widgets/queries/funded_areas_spec.rb
@@ -5,9 +5,18 @@ RSpec.describe Widgets::Queries::FundedAreas do
 
   describe "#call" do
     let(:result) { subject.call }
-    let!(:investment_1) { create :investment, year_invested: 2021, amount: 10, areas: ["equity_and_justice"] }
-    let!(:investment_2) { create :investment, year_invested: 2021, amount: 20, areas: ["equity_and_justice", "food_sovereignty"] }
-    let!(:ignored_investment) { create :investment, year_invested: 2030, amount: 20, areas: ["equity_and_justice"] }
+    let!(:investment_1) do
+      create :investment, year_invested: 2021, amount: 10, privacy: "all", areas: ["equity_and_justice"]
+    end
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, amount: 20, privacy: "aggregate_amount_funded", areas: ["equity_and_justice", "food_sovereignty"]
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", areas: ["equity_and_justice"]
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", areas: ["equity_and_justice"]
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.area.one"))

--- a/backend/spec/services/widgets/queries/funded_capital_types_spec.rb
+++ b/backend/spec/services/widgets/queries/funded_capital_types_spec.rb
@@ -5,9 +5,18 @@ RSpec.describe Widgets::Queries::FundedCapitalTypes do
 
   describe "#call" do
     let(:result) { subject.call }
-    let!(:investment_1) { create :investment, year_invested: 2021, amount: 10, capital_type: "grants" }
-    let!(:investment_2) { create :investment, year_invested: 2021, amount: 20, capital_type: "debt" }
-    let!(:ignored_investment) { create :investment, year_invested: 2030, amount: 20, capital_type: "grants" }
+    let!(:investment_1) do
+      create :investment, year_invested: 2021, amount: 10, privacy: "all", capital_type: "grants"
+    end
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, amount: 20, privacy: "aggregate_amount_funded", capital_type: "debt"
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", capital_type: "grants"
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", capital_type: "grants"
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.capital_type.one"))

--- a/backend/spec/services/widgets/queries/funded_demographics_spec.rb
+++ b/backend/spec/services/widgets/queries/funded_demographics_spec.rb
@@ -6,12 +6,17 @@ RSpec.describe Widgets::Queries::FundedDemographics do
   describe "#call" do
     let(:result) { subject.call }
     let!(:investment_1) do
-      create :investment, year_invested: 2021, amount: 10, demographics: ["black_or_african_american"]
+      create :investment, year_invested: 2021, amount: 10, privacy: "all", demographics: ["black_or_african_american"]
     end
     let!(:investment_2) do
-      create :investment, year_invested: 2021, amount: 20, demographics: ["black_or_african_american", "indigenous_tribal_nations"]
+      create :investment, year_invested: 2021, amount: 20, privacy: "aggregate_amount_funded", demographics: ["black_or_african_american", "indigenous_tribal_nations"]
     end
-    let!(:ignored_investment) { create :investment, year_invested: 2030, amount: 20 }
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", demographics: ["black_or_african_american"]
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", demographics: ["black_or_african_american"]
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.demographic.one"))

--- a/backend/spec/services/widgets/queries/funded_funder_types_spec.rb
+++ b/backend/spec/services/widgets/queries/funded_funder_types_spec.rb
@@ -8,10 +8,21 @@ RSpec.describe Widgets::Queries::FundedFunderTypes do
     let(:funder_1) { create :funder, funder_type: "accelerator" }
     let(:funder_2) { create :funder, funder_type: "accelerator" }
     let(:funder_3) { create :funder, funder_type: "advisory" }
-    let!(:investment_1) { create :investment, year_invested: 2021, amount: 10, funder: funder_1 }
-    let!(:investment_2) { create :investment, year_invested: 2021, amount: 20, funder: funder_2 }
-    let!(:investment_3) { create :investment, year_invested: 2021, amount: 20, funder: funder_3 }
-    let!(:ignored_investment) { create :investment, year_invested: 2030, amount: 20, funder: funder_1 }
+    let!(:investment_1) do
+      create :investment, year_invested: 2021, amount: 10, privacy: "all", funder: funder_1
+    end
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, amount: 20, privacy: "all", funder: funder_2
+    end
+    let!(:investment_3) do
+      create :investment, year_invested: 2021, amount: 20, privacy: "aggregate_amount_funded", funder: funder_3
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", funder: funder_1
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_1
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.funder_type.one"))

--- a/backend/spec/services/widgets/queries/funded_recipient_legal_statuses_spec.rb
+++ b/backend/spec/services/widgets/queries/funded_recipient_legal_statuses_spec.rb
@@ -8,10 +8,21 @@ RSpec.describe Widgets::Queries::FundedRecipientLegalStatuses do
     let(:project_1) { create :project, recipient: create(:recipient, recipient_legal_status: "for_profit") }
     let(:project_2) { create :project, recipient: create(:recipient, recipient_legal_status: "for_profit") }
     let(:project_3) { create :project, recipient: create(:recipient, recipient_legal_status: "government_organization") }
-    let!(:investment_1) { create :investment, year_invested: 2021, amount: 10, project: project_1 }
-    let!(:investment_2) { create :investment, year_invested: 2021, amount: 20, project: project_2 }
-    let!(:investment_3) { create :investment, year_invested: 2021, amount: 20, project: project_3 }
-    let!(:ignored_investment) { create :investment, year_invested: 2030, amount: 20, project: project_1 }
+    let!(:investment_1) do
+      create :investment, year_invested: 2021, amount: 10, privacy: "all", project: project_1
+    end
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, amount: 20, privacy: "all", project: project_2
+    end
+    let!(:investment_3) do
+      create :investment, year_invested: 2021, amount: 20, privacy: "aggregate_amount_funded", project: project_3
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", project: project_1
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", project: project_1
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.recipient_legal_status.one"))

--- a/backend/spec/services/widgets/queries/funded_subgeographics_spec.rb
+++ b/backend/spec/services/widgets/queries/funded_subgeographics_spec.rb
@@ -33,9 +33,18 @@ RSpec.describe Widgets::Queries::FundedSubgeographics do
       let!(:country_2) { create :subgeographic, geographic: :countries, name: "CCCC" }
       let!(:ignored_country) { create :subgeographic, geographic: :countries, name: "BBBB" }
       let!(:funder) { create :funder, subgeographics: [country_1] }
-      let!(:investment_1) { create :investment, year_invested: 2021, amount: 10, funder: funder, subgeographics: [region] }
-      let!(:investment_2) { create :investment, year_invested: 2021, amount: 20, funder: funder, subgeographics: [country_1, country_2] }
-      let!(:ignored_investment) { create :investment, year_invested: 2030, amount: 10, funder: funder }
+      let!(:investment_1) do
+        create :investment, year_invested: 2021, amount: 10, privacy: "all", funder: funder, subgeographics: [region]
+      end
+      let!(:investment_2) do
+        create :investment, year_invested: 2021, amount: 20, privacy: "aggregate_amount_funded", funder: funder, subgeographics: [country_1, country_2]
+      end
+      let!(:ignored_investment_with_different_year) do
+        create :investment, year_invested: 2030, privacy: "all", funder: funder, subgeographics: [region]
+      end
+      let!(:ignored_investment_with_different_privacy) do
+        create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder, subgeographics: [region]
+      end
 
       it "contains correct header" do
         expect(result[:headers].first[:label]).to eq(Geographic.find("countries").name)
@@ -65,9 +74,18 @@ RSpec.describe Widgets::Queries::FundedSubgeographics do
       let!(:region_2) { create :subgeographic, geographic: :regions, name: "CCCC" }
       let!(:region_3) { create :subgeographic, geographic: :regions, name: "BBBB" }
       let!(:funder) { create :funder, subgeographics: [region_1] }
-      let!(:investment_1) { create :investment, year_invested: 2021, amount: 10, funder: funder, subgeographics: [state] }
-      let!(:investment_2) { create :investment, year_invested: 2021, amount: 20, funder: funder, subgeographics: [region_1, region_2] }
-      let!(:ignored_investment) { create :investment, year_invested: 2030, amount: 10, funder: funder }
+      let!(:investment_1) do
+        create :investment, year_invested: 2021, amount: 10, privacy: "all", funder: funder, subgeographics: [state]
+      end
+      let!(:investment_2) do
+        create :investment, year_invested: 2021, amount: 20, privacy: "aggregate_amount_funded", funder: funder, subgeographics: [region_1, region_2]
+      end
+      let!(:ignored_investment_with_different_year) do
+        create :investment, year_invested: 2030, privacy: "all", funder: funder, subgeographics: [state]
+      end
+      let!(:ignored_investment_with_different_privacy) do
+        create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder, subgeographics: [state]
+      end
 
       it "contains correct header" do
         expect(result[:headers].first[:label]).to eq(Geographic.find("regions").name)

--- a/backend/spec/services/widgets/queries/summary_spec.rb
+++ b/backend/spec/services/widgets/queries/summary_spec.rb
@@ -9,9 +9,18 @@ RSpec.describe Widgets::Queries::Summary do
     let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030) }
     let!(:project_1) { create :project }
     let!(:project_2) { create :project }
-    let!(:investment_1) { create :investment, funder: funder, project: project_1, year_invested: 2021, capital_type: "grants", amount: 10 }
-    let!(:investment_2) { create :investment, funder: funder, project: project_2, year_invested: 2021, capital_type: "debt", amount: 10 }
-    let!(:ignored_investment) { create :investment, funder: funder, project: project_2, year_invested: 2030 }
+    let!(:investment_1) do
+      create :investment, funder: funder, project: project_1, year_invested: 2021, privacy: "all", capital_type: "grants", amount: 10
+    end
+    let!(:investment_2) do
+      create :investment, funder: funder, project: project_2, year_invested: 2021, privacy: "aggregate_amount_funded", capital_type: "debt", amount: 10
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, funder: funder, project: project_2, year_invested: 2030, privacy: "all"
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, funder: funder, project: project_2, year_invested: 2021, privacy: "visible_only_to_members"
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("widgets.headers.summary.total_number_funders"))

--- a/backend/spec/services/widgets/queries/total_funders_capital_types_spec.rb
+++ b/backend/spec/services/widgets/queries/total_funders_capital_types_spec.rb
@@ -7,11 +7,24 @@ RSpec.describe Widgets::Queries::TotalFundersCapitalTypes do
     let(:result) { subject.call }
     let!(:funder_1) { create :funder }
     let!(:funder_2) { create :funder }
-    let!(:investment_1) { create :investment, year_invested: 2021, funder: funder_1, capital_type: "grants" }
-    let!(:investment_2) { create :investment, year_invested: 2021, funder: funder_1, capital_type: "grants" }
-    let!(:investment_3) { create :investment, year_invested: 2021, funder: funder_1, capital_type: "debt" }
-    let!(:investment_4) { create :investment, year_invested: 2021, funder: funder_2, capital_type: "debt" }
-    let!(:ignored_investment) { create :investment, year_invested: 2030, funder: funder_1, capital_type: "grants" }
+    let!(:investment_1) do
+      create :investment, year_invested: 2021, privacy: "all", funder: funder_1, capital_type: "grants"
+    end
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, privacy: "aggregate_amount_funded", funder: funder_1, capital_type: "grants"
+    end
+    let!(:investment_3) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_1, capital_type: "debt"
+    end
+    let!(:investment_4) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_staff", funder: funder_2, capital_type: "debt"
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", funder: funder_1, capital_type: "grants"
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "visible_only_to_members", funder: funder_1, capital_type: "grants"
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.capital_type.one"))

--- a/backend/spec/services/widgets/queries/total_funders_demographics_spec.rb
+++ b/backend/spec/services/widgets/queries/total_funders_demographics_spec.rb
@@ -8,11 +8,18 @@ RSpec.describe Widgets::Queries::TotalFundersDemographics do
     let!(:funder_1) { create :funder, date_joined_fora: Date.new(2021) }
     let!(:funder_2) { create :funder, date_joined_fora: Date.new(2021) }
     let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030) }
-    let!(:investment_1) { create :investment, funder: funder_1, demographics: ["black_or_african_american"] }
-    let!(:investment_2) do
-      create :investment, funder: funder_2, demographics: ["black_or_african_american", "indigenous_tribal_nations"]
+    let!(:investment_1) do
+      create :investment, funder: funder_1, privacy: "all", demographics: ["black_or_african_american"]
     end
-    let!(:ignored_investment) { create :investment, funder: ignored_funder }
+    let!(:investment_2) do
+      create :investment, funder: funder_2, privacy: "amount_funded_visible_only_to_members", demographics: ["black_or_african_american", "indigenous_tribal_nations"]
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, privacy: "all", funder: ignored_funder, demographics: ["black_or_african_american"]
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, privacy: "visible_only_to_members", funder: funder_1, demographics: ["black_or_african_american"]
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.demographic.one"))

--- a/backend/spec/services/widgets/queries/total_projects_capital_types_spec.rb
+++ b/backend/spec/services/widgets/queries/total_projects_capital_types_spec.rb
@@ -5,9 +5,18 @@ RSpec.describe Widgets::Queries::TotalProjectsCapitalTypes do
 
   describe "#call" do
     let(:result) { subject.call }
-    let!(:investment_1) { create :investment, year_invested: 2021, capital_type: "grants" }
-    let!(:investment_2) { create :investment, year_invested: 2021, capital_type: "debt" }
-    let!(:ignored_investment_1) { create :investment, year_invested: 2030, capital_type: "grants" }
+    let!(:investment_1) do
+      create :investment, year_invested: 2021, privacy: "all", capital_type: "grants"
+    end
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", capital_type: "debt"
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", capital_type: "grants"
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "visible_only_to_members", capital_type: "grants"
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.capital_type.one"))

--- a/backend/spec/services/widgets/queries/total_projects_demographics_spec.rb
+++ b/backend/spec/services/widgets/queries/total_projects_demographics_spec.rb
@@ -5,9 +5,18 @@ RSpec.describe Widgets::Queries::TotalProjectsDemographics do
 
   describe "#call" do
     let(:result) { subject.call }
-    let!(:investment_1) { create :investment, year_invested: 2021, demographics: ["black_or_african_american"] }
-    let!(:investment_2) { create :investment, year_invested: 2021, demographics: ["black_or_african_american", "indigenous_tribal_nations"] }
-    let!(:ignored_investment) { create :investment, year_invested: 2030 }
+    let!(:investment_1) do
+      create :investment, year_invested: 2021, privacy: "all", demographics: ["black_or_african_american"]
+    end
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", demographics: ["black_or_african_american", "indigenous_tribal_nations"]
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", demographics: ["black_or_african_american"]
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "visible_only_to_members", demographics: ["black_or_african_american"]
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.demographic.one"))

--- a/backend/spec/services/widgets/queries/total_projects_funders_areas_spec.rb
+++ b/backend/spec/services/widgets/queries/total_projects_funders_areas_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe Widgets::Queries::TotalProjectsFundersAreas do
     let(:result) { subject.call }
     let(:funder_1) { create :funder, date_joined_fora: Date.new(2021), areas: ["equity_and_justice"] }
     let(:funder_2) { create :funder, date_joined_fora: Date.new(2021), areas: ["food_sovereignty"] }
-    let!(:investment_1) { create :investment, year_invested: 2021, funder: funder_1, areas: ["equity_and_justice"] }
-    let!(:investment_2) { create :investment, year_invested: 2021, funder: funder_2, areas: ["equity_and_justice", "food_sovereignty"] }
-    let!(:ignored_investment) { create :investment, year_invested: 2030, funder: funder_2, areas: ["equity_and_justice"] }
+    let!(:investment_1) do
+      create :investment, year_invested: 2021, privacy: "all", funder: funder_1, areas: ["equity_and_justice"]
+    end
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_2, areas: ["equity_and_justice", "food_sovereignty"]
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", funder: funder_2, areas: ["equity_and_justice"]
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "visible_only_to_members", funder: funder_2, areas: ["equity_and_justice"]
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.area.one"))

--- a/backend/spec/services/widgets/queries/total_projects_funders_subgeographics_spec.rb
+++ b/backend/spec/services/widgets/queries/total_projects_funders_subgeographics_spec.rb
@@ -37,9 +37,18 @@ RSpec.describe Widgets::Queries::TotalProjectsFundersSubgeographics do
       let!(:funder_1) { create :funder, date_joined_fora: Date.new(2021), subgeographics: [country_1] }
       let!(:funder_2) { create :funder, date_joined_fora: Date.new(2021), subgeographics: [country_2] }
       let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030), subgeographics: [country_2] }
-      let!(:investment_1) { create :investment, year_invested: 2021, funder: funder_1, subgeographics: [region] }
-      let!(:investment_2) { create :investment, year_invested: 2021, funder: funder_2, subgeographics: [country_1, country_2] }
-      let!(:ignored_investment) { create :investment, year_invested: 2030, funder: funder_1 }
+      let!(:investment_1) do
+        create :investment, year_invested: 2021, privacy: "all", funder: funder_1, subgeographics: [region]
+      end
+      let!(:investment_2) do
+        create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_2, subgeographics: [country_1, country_2]
+      end
+      let!(:ignored_investment_with_different_year) do
+        create :investment, year_invested: 2030, privacy: "all", funder: funder_1, subgeographics: [region]
+      end
+      let!(:ignored_investment_with_different_privacy) do
+        create :investment, year_invested: 2021, privacy: "visible_only_to_members", funder: funder_1, subgeographics: [region]
+      end
 
       it "contains correct header" do
         expect(result[:headers].first[:label]).to eq(Geographic.find("countries").name)
@@ -79,12 +88,17 @@ RSpec.describe Widgets::Queries::TotalProjectsFundersSubgeographics do
       let!(:funder_2) { create :funder, date_joined_fora: Date.new(2021), subgeographics: [region_2] }
       let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030), subgeographics: [region_2] }
       let!(:investment_1) do
-        create :investment, year_invested: 2021, amount: 10, funder: funder_1, subgeographics: [state]
+        create :investment, year_invested: 2021, privacy: "all", funder: funder_1, subgeographics: [state]
       end
       let!(:investment_2) do
-        create :investment, year_invested: 2021, amount: 20, funder: funder_2, subgeographics: [region_1, region_2]
+        create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_2, subgeographics: [region_1, region_2]
       end
-      let!(:ignored_investment) { create :investment, year_invested: 2030, funder: funder_1 }
+      let!(:ignored_investment_with_different_year) do
+        create :investment, year_invested: 2030, privacy: "all", funder: funder_1, subgeographics: [state]
+      end
+      let!(:ignored_investment_with_different_privacy) do
+        create :investment, year_invested: 2021, privacy: "visible_only_to_members", funder: funder_1, subgeographics: [state]
+      end
 
       it "contains correct header" do
         expect(result[:headers].first[:label]).to eq(Geographic.find("regions").name)

--- a/backend/spec/services/widgets/queries/total_projects_recipient_legal_statuses_spec.rb
+++ b/backend/spec/services/widgets/queries/total_projects_recipient_legal_statuses_spec.rb
@@ -8,10 +8,19 @@ RSpec.describe Widgets::Queries::TotalProjectsRecipientLegalStatuses do
     let(:project_1) { create :project, recipient: create(:recipient, recipient_legal_status: "for_profit") }
     let(:project_2) { create :project, recipient: create(:recipient, recipient_legal_status: "for_profit") }
     let(:project_3) { create :project, recipient: create(:recipient, recipient_legal_status: "government_organization") }
-    let!(:investment_1) { create :investment, year_invested: 2021, project: project_1 }
-    let!(:investment_2) { create :investment, year_invested: 2021, project: project_2 }
-    let!(:investment_3) { create :investment, year_invested: 2021, project: project_3 }
-    let!(:ignored_investment) { create :investment, year_invested: 2030, project: project_1 }
+    let!(:investment_1) { create :investment, year_invested: 2021, privacy: "all", project: project_1 }
+    let!(:investment_2) do
+      create :investment, year_invested: 2021, privacy: "aggregate_amount_funded", project: project_2
+    end
+    let!(:investment_3) do
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", project: project_3
+    end
+    let!(:ignored_investment_with_different_year) do
+      create :investment, year_invested: 2030, privacy: "all", project: project_1
+    end
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, year_invested: 2021, privacy: "visible_only_to_members", project: project_1
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.recipient_legal_status.one"))


### PR DESCRIPTION
Making sure that widgets which show:
 - total numbers (count) take into account only publicly visible investments (amount funded does not matter)
 - total amounts (sum) take into account only investments which allow to aggregate funded amount 

https://vizzuality.atlassian.net/browse/FORA-274

[FORA-274]: https://vizzuality.atlassian.net/browse/FORA-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ