### PR TITLE
FORA-278 Background jobs: capistrano-sidekiq with systemd system-wide service

### DIFF
--- a/backend/Capfile
+++ b/backend/Capfile
@@ -14,5 +14,11 @@ require "capistrano/rvm"
 require "capistrano/passenger"
 require "capistrano-db-tasks"
 
+require "capistrano/sidekiq"
+install_plugin Capistrano::Sidekiq # Default sidekiq tasks
+# Then select your service manager
+install_plugin Capistrano::Sidekiq::Systemd
+# service unit in /etc/systemd/user/sidekiq.service
+
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -71,6 +71,7 @@ group :development do
   gem "capistrano-passenger", "~> 0.2.1", require: false
   gem "capistrano-rails", "~> 1.6", require: false
   gem "capistrano-rvm", "~> 0.1.2", require: false
+  gem "capistrano-sidekiq"
   gem "capistrano-yarn", "~> 2.0.2", require: false
   gem "capistrano-db-tasks", "~> 0.6", require: false
   gem "bcrypt_pbkdf"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -134,6 +134,10 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
+    capistrano-sidekiq (2.3.0)
+      capistrano (>= 3.9.0)
+      capistrano-bundler
+      sidekiq (>= 6.0)
     capistrano-yarn (2.0.2)
       capistrano (~> 3.0)
     capybara (3.37.1)
@@ -470,6 +474,7 @@ DEPENDENCIES
   capistrano-passenger (~> 0.2.1)
   capistrano-rails (~> 1.6)
   capistrano-rvm (~> 0.1.2)
+  capistrano-sidekiq
   capistrano-yarn (~> 2.0.2)
   capybara (>= 3.26)
   closure_tree

--- a/backend/config/deploy.rb
+++ b/backend/config/deploy.rb
@@ -18,6 +18,8 @@ set :db_local_clean, true
 set :db_remote_clean, true
 
 set :init_system, :systemd
+set :sidekiq_service_unit_user, :system
+set :systemctl_user, :system
 
 set :passenger_restart_with_sudo, true
 set :passenger_roles, :web

--- a/backend/config/deploy/staging.rb
+++ b/backend/config/deploy/staging.rb
@@ -1,2 +1,2 @@
-server "52.1.158.47", user: "ubuntu", roles: %w[web]
 set :branch, "staging"
+server "52.1.158.47", user: "ubuntu", roles: %w[web app db]

--- a/backend/config/systemd/README.md
+++ b/backend/config/systemd/README.md
@@ -1,0 +1,7 @@
+To install sidekiq as a `systemd` system-wide service on Ubuntu:
+- sidekiq.service goes into `/lib/systemd/system/sidekiq.service` - check the rvm path and the application directory
+- `sudo systemctl enable sidekiq`
+
+The service file is based on this [sidekiq template](https://raw.githubusercontent.com/mperham/sidekiq/main/examples/systemd/sidekiq.service).
+
+The capistrano deploy script is configured to work with ubuntu user, who can restart system-wide services using sudo.

--- a/backend/config/systemd/sidekiq.service
+++ b/backend/config/systemd/sidekiq.service
@@ -1,0 +1,90 @@
+#
+# This file tells systemd how to run Sidekiq as a 24/7 long-running daemon.
+#
+# Customize this file based on your bundler location, app directory, etc.
+#
+# If you are going to run this as a user service (or you are going to use capistrano-sidekiq)
+# Customize and copy this to ~/.config/systemd/user
+# Then run:
+#   - systemctl --user enable sidekiq
+#   - systemctl --user {start,stop,restart} sidekiq
+#
+# If you are going to run this as a system service
+# Customize and copy this into /usr/lib/systemd/system (CentOS) or /lib/systemd/system (Ubuntu).
+# Then run:
+#   - systemctl enable sidekiq
+#   - systemctl {start,stop,restart} sidekiq
+#
+# This file corresponds to a single Sidekiq process.  Add multiple copies
+# to run multiple processes (sidekiq-1, sidekiq-2, etc).
+#
+# Use `journalctl -u sidekiq -rn 100` to view the last 100 lines of log output.
+#
+[Unit]
+Description=sidekiq
+# start us only once the network and logging subsystems are available,
+# consider adding redis-server.service if Redis is local and systemd-managed.
+After=syslog.target network.target
+
+# See these pages for lots of options:
+#
+#   https://www.freedesktop.org/software/systemd/man/systemd.service.html
+#   https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+#
+# THOSE PAGES ARE CRITICAL FOR ANY LINUX DEVOPS WORK; read them multiple
+# times! systemd is a critical tool for all developers to know and understand.
+#
+[Service]
+#
+#      !!!!  !!!!  !!!!
+#
+# As of v6.0.6, Sidekiq automatically supports systemd's `Type=notify` and watchdog service
+# monitoring. If you are using an earlier version of Sidekiq, change this to `Type=simple`
+# and remove the `WatchdogSec` line.
+#
+#      !!!!  !!!!  !!!!
+#
+Type=notify
+# If your Sidekiq process locks up, systemd's watchdog will restart it within seconds.
+WatchdogSec=10
+
+WorkingDirectory=/var/www/fora-backend/current
+# If you use rbenv:
+# ExecStart=/bin/bash -lc 'exec /home/deploy/.rbenv/shims/bundle exec sidekiq -e production'
+# If you use the system's ruby:
+# ExecStart=/usr/local/bin/bundle exec sidekiq -e production
+# If you use rvm in production without gemset and your ruby version is 2.6.5
+# ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5/wrappers/bundle exec sidekiq -e production
+# If you use rvm in production with gemset and your ruby version is 2.6.5
+# ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5@gemset-name/wrappers/bundle exec sidekiq -e production
+# If you use rvm in production with gemset and ruby version/gemset is specified in .ruby-version,
+# .ruby-gemsetor or .rvmrc file in the working directory
+# ExecStart=/home/ubuntu/.rvm/bin/rvm in /var/www/fora-backend/current do bundle exec sidekiq -e staging
+ExecStart=/usr/share/rvm/bin/rvm in /var/www/fora-backend/current do bundle exec sidekiq -e staging
+
+# Use `systemctl kill -s TSTP sidekiq` to quiet the Sidekiq process
+
+# Uncomment this if you are going to use this as a system service
+# if using as a user service then leave commented out, or you will get an error trying to start the service
+# !!! Change this to your deploy user account if you are using this as a system service !!!
+# User=deploy
+# Group=deploy
+# UMask=0002
+
+# Greatly reduce Ruby memory fragmentation and heap usage
+# https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
+Environment=MALLOC_ARENA_MAX=2
+
+# if we crash, restart
+RestartSec=1
+Restart=always
+
+# output goes to /var/log/syslog (Ubuntu) or /var/log/messages (CentOS)
+StandardOutput=syslog
+StandardError=syslog
+
+# This will default to "bundler" if we don't specify it
+SyslogIdentifier=sidekiq
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Sidekiq is restarted when deploying.

Also, the change to the list of capistrano server roles fixes problem with migrations not running during deployment.

https://vizzuality.atlassian.net/browse/FORA-278
https://vizzuality.atlassian.net/browse/FORA-277