### PR TITLE
Revalidate: by id and all pages

### DIFF
--- a/client/src/containers/funder/overview/address/component.tsx
+++ b/client/src/containers/funder/overview/address/component.tsx
@@ -19,7 +19,7 @@ const FunderAddress = () => {
 
   const ADDRESS = [
     officeCity,
-    ...(!!officeState.name ? [officeState.name] : []),
+    ...(!!officeState?.name ? [officeState.name] : []),
     officeCountry.name,
   ];
 

--- a/client/src/pages/api/revalidate/funders.ts
+++ b/client/src/pages/api/revalidate/funders.ts
@@ -1,0 +1,46 @@
+import { fetchFunders } from 'hooks/funders';
+
+async function handler(req, res) {
+  // Check for secret to confirm this is a valid request
+  if (req.query.secret !== process.env.SECRET_TOKEN) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  // Revalidate all pages
+  if (!req.query.id) {
+    try {
+      // fetch all funders
+      const { data } = await fetchFunders({
+        disablePagination: true,
+      });
+
+      // revalidate each funder
+      data.forEach(async (funder) => {
+        await res.revalidate(`/funders/${funder.id}`);
+      });
+
+      return res.json({ revalidated: true });
+    } catch (err) {
+      // If there was an error, Next.js will continue
+      // to show the last successfully generated page
+      console.error(err);
+      return res.status(500).send('Error revalidating');
+    }
+  }
+
+  if (req.query.id) {
+    try {
+      // this should be the actual path not a rewritten path
+      // e.g. for "/funders/[slug]" this should be "/funders/post-1"
+      await res.revalidate(`/funders/${req.query.id}`);
+      return res.json({ revalidated: true });
+    } catch (err) {
+      // If there was an error, Next.js will continue
+      // to show the last successfully generated page
+      console.error(err);
+      return res.status(500).send('Error revalidating');
+    }
+  }
+}
+
+export default handler;

--- a/client/src/pages/api/revalidate/projects.ts
+++ b/client/src/pages/api/revalidate/projects.ts
@@ -1,0 +1,46 @@
+import { fetchProjects } from 'hooks/projects';
+
+async function handler(req, res) {
+  // Check for secret to confirm this is a valid request
+  if (req.query.secret !== process.env.SECRET_TOKEN) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  // Revalidate all pages
+  if (!req.query.id) {
+    try {
+      // fetch all projects
+      const { data } = await fetchProjects({
+        disablePagination: true,
+      });
+
+      // revalidate each project
+      data.forEach(async (project) => {
+        await res.revalidate(`/projects/${project.id}`);
+      });
+
+      return res.json({ revalidated: true });
+    } catch (err) {
+      // If there was an error, Next.js will continue
+      // to show the last successfully generated page
+      console.error(err);
+      return res.status(500).send('Error revalidating');
+    }
+  }
+
+  if (req.query.id) {
+    try {
+      // this should be the actual path not a rewritten path
+      // e.g. for "/projects/[slug]" this should be "/projects/post-1"
+      await res.revalidate(`/projects/${req.query.id}`);
+      return res.json({ revalidated: true });
+    } catch (err) {
+      // If there was an error, Next.js will continue
+      // to show the last successfully generated page
+      console.error(err);
+      return res.status(500).send('Error revalidating');
+    }
+  }
+}
+
+export default handler;


### PR DESCRIPTION
@martintomas Here you have the urls from the app where you can trigger the revalidation of the static pages for funders and projects.

Funders
- all funders: `/api/revalidate/funders?secret={process.env.SECRET_TOKEN}`
- one funder: `/api/revalidate/funders?secret={process.env.SECRET_TOKEN}&id={funderId}`

Projects
- all projects: `/api/revalidate/projects?secret={process.env.SECRET_TOKEN}`
- one project: `/api/revalidate/projects?secret={process.env.SECRET_TOKEN}&id={projectId}`