### PR TITLE
fix: Import Other Pacific Islands countries as states

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,15 +1,15 @@
 require "factory_bot_rails"
 
 if Rails.env.development?
-  Subgeographic.delete_all
-  SubgeographicGeometry.delete_all
-  Investment.delete_all
-  Funder.delete_all
-  Project.delete_all
-  Recipient.delete_all
-  Widget.delete_all
-  Upload.delete_all
-  Admin.delete_all
+  Investment.destroy_all
+  Funder.destroy_all
+  Project.destroy_all
+  Recipient.destroy_all
+  Widget.destroy_all
+  Upload.destroy_all
+  Admin.destroy_all
+  Subgeographic.destroy_all
+  SubgeographicGeometry.destroy_all
 
   Admin.create! first_name: "Admin", last_name: "Example", password: "SuperSecret1234", email: "admin@example.com"
 

--- a/backend/spec/services/importers/uploads/submodules/subgeographics_spec.rb
+++ b/backend/spec/services/importers/uploads/submodules/subgeographics_spec.rb
@@ -77,5 +77,18 @@ RSpec.describe DummySubgeographicsModule do
         expect(record.subgeographics).to eq([state])
       end
     end
+
+    context "when multiple geographic types are combined" do
+      let!(:country) { create :subgeographic, geographic: :countries, name: "Croatia" }
+      let!(:state) { create :subgeographic, geographic: :states, name: "Georgia", parent: usa_country }
+      let(:countries) { [usa_country.name, country.name] }
+      let(:states) { [described_class::OUTSIDE_US_SUBGEOGRAPHIC, state.name] }
+
+      before { subject.call }
+
+      it "assigns correct subgeographics to record" do
+        expect(record.subgeographics).to match_array([country, state])
+      end
+    end
   end
 end

--- a/backend/spec/services/importers/uploads/submodules/subgeographics_spec.rb
+++ b/backend/spec/services/importers/uploads/submodules/subgeographics_spec.rb
@@ -77,30 +77,5 @@ RSpec.describe DummySubgeographicsModule do
         expect(record.subgeographics).to eq([state])
       end
     end
-
-    context "when geographic focus should be transformed to region" do
-      let(:transformed_region) { described_class::COUNTRIES_TO_REGIONS.first }
-      let!(:region) { create :subgeographic, geographic: :regions, name: transformed_region.last, parent: usa_country }
-      let(:countries) { [transformed_region.first, usa_country.name] }
-
-      before { subject.call }
-
-      it "assigns region instead of country subgeographic to record" do
-        expect(record.subgeographics).to eq([region])
-      end
-    end
-
-    context "when multiple geographic types are combined" do
-      let!(:country) { create :subgeographic, geographic: :countries, name: "Croatia" }
-      let!(:state) { create :subgeographic, geographic: :states, name: "Georgia", parent: usa_country }
-      let(:countries) { [usa_country.name, country.name] }
-      let(:states) { [described_class::OUTSIDE_US_SUBGEOGRAPHIC, state.name] }
-
-      before { subject.call }
-
-      it "assigns correct subgeographics to record" do
-        expect(record.subgeographics).to match_array([country, state])
-      end
-    end
   end
 end


### PR DESCRIPTION
This PR contains minor refactoring of Subgeographics submodule used during data import. It was decided that these countries:
 - Guam
 - American Samoa
 - Northern Mariana Islands
 - Palau
 - Micronesia
 - Marshall Islands
 - United States Minor Outlying Isl

should be imported as `Other Pacific Islands` **states**. Previous implementation imported these countries as `Other Pacific Islands` **regions** which was causing issues during filtering. I have removed `COUNTRIES_TO_REGIONS` constant from subgeographics submodule, because it is not needed anymore.

I have also slightly tweaked `seed.rb` script and replaced `delete_all` by `destroy_all`, because `delete_all` does not deleted blob attachment data from db which could generate some problems at future.

https://vizzuality.atlassian.net/browse/FORA-293