### PR TITLE
refactoring: All funder data at widgets respect year of investment instead of date joined fora

### DIFF
--- a/backend/app/services/widgets/queries/summary.rb
+++ b/backend/app/services/widgets/queries/summary.rb
@@ -14,7 +14,7 @@ module Widgets
 
       def values
         [[
-          {value: Funder.where(date_joined_fora: ..DateTime.new(year).end_of_year).count.to_f},
+          {value: Investment.can_be_shown_without_amount.where(year_invested: year).count("DISTINCT investments.funder_id").to_f},
           {value: Investment.can_be_shown_without_amount.where(year_invested: year).count("DISTINCT investments.project_id").to_f},
           {value: Investment.can_show_aggregated_amount.where(year_invested: year).sum(:amount).to_f},
           {value: Investment.can_show_aggregated_amount.where(year_invested: year).where(capital_type: %w[grants re_grants]).sum(:amount).to_f}

--- a/backend/app/services/widgets/queries/total_funders_capital_acceptances.rb
+++ b/backend/app/services/widgets/queries/total_funders_capital_acceptances.rb
@@ -20,7 +20,8 @@ module Widgets
       end
 
       def funders
-        @funders ||= Funder.where(date_joined_fora: ..DateTime.new(year).end_of_year).group("unnest(capital_acceptances)").count
+        @funders ||= Investment.can_be_shown_without_amount.joins(:funder).where(year_invested: year)
+          .group("unnest(funders.capital_acceptances)").count("DISTINCT funders.id")
       end
     end
   end

--- a/backend/app/services/widgets/queries/total_funders_demographics.rb
+++ b/backend/app/services/widgets/queries/total_funders_demographics.rb
@@ -20,7 +20,7 @@ module Widgets
       end
 
       def investments
-        @investments ||= Investment.can_be_shown_without_amount.joins(:funder).where(funders: {date_joined_fora: ..DateTime.new(year).end_of_year})
+        @investments ||= Investment.can_be_shown_without_amount.where(year_invested: year)
           .group("unnest(investments.demographics)").count("DISTINCT investments.funder_id")
       end
     end

--- a/backend/app/services/widgets/queries/total_funders_funder_types.rb
+++ b/backend/app/services/widgets/queries/total_funders_funder_types.rb
@@ -20,7 +20,8 @@ module Widgets
       end
 
       def funders
-        @funders ||= Funder.where(date_joined_fora: ..DateTime.new(year).end_of_year).group("funder_type").count
+        @funders ||= Investment.can_be_shown_without_amount.joins(:funder).where(year_invested: year)
+          .group("funders.funder_type").count("DISTINCT funders.id")
       end
     end
   end

--- a/backend/app/services/widgets/queries/total_projects_funders_areas.rb
+++ b/backend/app/services/widgets/queries/total_projects_funders_areas.rb
@@ -27,7 +27,8 @@ module Widgets
       end
 
       def total_funders
-        @total_funders ||= Funder.where(date_joined_fora: ..DateTime.new(year).end_of_year).group("unnest(areas)").count
+        @total_funders ||= Investment.can_be_shown_without_amount.where(year_invested: year)
+          .group("unnest(areas)").count("DISTINCT investments.funder_id")
       end
     end
   end

--- a/backend/app/services/widgets/queries/total_projects_funders_subgeographics.rb
+++ b/backend/app/services/widgets/queries/total_projects_funders_subgeographics.rb
@@ -42,8 +42,8 @@ module Widgets
       end
 
       def total_funders
-        @total_funders ||= Funder.where(date_joined_fora: ..DateTime.new(year).end_of_year).joins(:subgeographic_ancestors)
-          .group("ancestor_id").count("DISTINCT funders.id")
+        @total_funders ||= Investment.can_be_shown_without_amount.where(year_invested: year).joins(:subgeographic_ancestors)
+          .group("ancestor_id").count("DISTINCT investments.funder_id")
       end
 
       def subgeographics

--- a/backend/spec/services/widgets/queries/summary_spec.rb
+++ b/backend/spec/services/widgets/queries/summary_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Widgets::Queries::Summary do
 
   describe "#call" do
     let(:result) { subject.call }
-    let!(:funder) { create :funder, date_joined_fora: Date.new(2021) }
-    let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030) }
+    let!(:funder) { create :funder }
+    let!(:ignored_funder) { create :funder }
     let!(:project_1) { create :project }
     let!(:project_2) { create :project }
     let!(:investment_1) do
@@ -16,7 +16,7 @@ RSpec.describe Widgets::Queries::Summary do
       create :investment, funder: funder, project: project_2, year_invested: 2021, privacy: "aggregate_amount_funded", capital_type: "debt", amount: 10
     end
     let!(:ignored_investment_with_different_year) do
-      create :investment, funder: funder, project: project_2, year_invested: 2030, privacy: "all"
+      create :investment, funder: ignored_funder, project: project_2, year_invested: 2030, privacy: "all"
     end
     let!(:ignored_investment_with_different_privacy) do
       create :investment, funder: funder, project: project_2, year_invested: 2021, privacy: "visible_only_to_members"

--- a/backend/spec/services/widgets/queries/total_funders_capital_acceptances_spec.rb
+++ b/backend/spec/services/widgets/queries/total_funders_capital_acceptances_spec.rb
@@ -5,9 +5,16 @@ RSpec.describe Widgets::Queries::TotalFundersCapitalAcceptances do
 
   describe "#call" do
     let(:result) { subject.call }
-    let!(:funder_1) { create :funder, date_joined_fora: Date.new(2021), capital_acceptances: ["advises_and_manages_capital"] }
-    let!(:funder_2) { create :funder, date_joined_fora: Date.new(2021), capital_acceptances: ["advises_and_manages_capital", "does_not_provide_funding"] }
-    let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030), capital_acceptances: ["advises_and_manages_capital"] }
+    let!(:funder_1) { create :funder, capital_acceptances: ["advises_and_manages_capital"] }
+    let!(:funder_2) { create :funder, capital_acceptances: ["advises_and_manages_capital", "does_not_provide_funding"] }
+    let!(:ignored_funder) { create :funder, capital_acceptances: ["advises_and_manages_capital"] }
+    let!(:ignored_funder_different_privacy) { create :funder, capital_acceptances: ["advises_and_manages_capital"] }
+    let!(:investment_1) { create :investment, funder: funder_1, year_invested: 2021, privacy: "all" }
+    let!(:investment_2) { create :investment, funder: funder_2, year_invested: 2021, privacy: "all" }
+    let!(:ignored_investment) { create :investment, funder: ignored_funder, year_invested: 2030, privacy: "all" }
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, funder: ignored_funder_different_privacy, year_invested: 2021, privacy: "visible_only_to_members"
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.capital_acceptance.one"))

--- a/backend/spec/services/widgets/queries/total_funders_demographics_spec.rb
+++ b/backend/spec/services/widgets/queries/total_funders_demographics_spec.rb
@@ -5,20 +5,17 @@ RSpec.describe Widgets::Queries::TotalFundersDemographics do
 
   describe "#call" do
     let(:result) { subject.call }
-    let!(:funder_1) { create :funder, date_joined_fora: Date.new(2021) }
-    let!(:funder_2) { create :funder, date_joined_fora: Date.new(2021) }
-    let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030) }
     let!(:investment_1) do
-      create :investment, funder: funder_1, privacy: "all", demographics: ["black_or_african_american"]
+      create :investment, year_invested: 2021, privacy: "all", demographics: ["black_or_african_american"]
     end
     let!(:investment_2) do
-      create :investment, funder: funder_2, privacy: "amount_funded_visible_only_to_members", demographics: ["black_or_african_american", "indigenous_tribal_nations"]
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", demographics: ["black_or_african_american", "indigenous_tribal_nations"]
     end
     let!(:ignored_investment_with_different_year) do
-      create :investment, privacy: "all", funder: ignored_funder, demographics: ["black_or_african_american"]
+      create :investment, privacy: "all", year_invested: 2030, demographics: ["black_or_african_american"]
     end
     let!(:ignored_investment_with_different_privacy) do
-      create :investment, privacy: "visible_only_to_members", funder: funder_1, demographics: ["black_or_african_american"]
+      create :investment, privacy: "visible_only_to_members", year_invested: 2021, demographics: ["black_or_african_american"]
     end
 
     it "contains correct header" do

--- a/backend/spec/services/widgets/queries/total_funders_funder_types_spec.rb
+++ b/backend/spec/services/widgets/queries/total_funders_funder_types_spec.rb
@@ -5,10 +5,18 @@ RSpec.describe Widgets::Queries::TotalFundersFunderTypes do
 
   describe "#call" do
     let(:result) { subject.call }
-    let!(:funder_1) { create :funder, date_joined_fora: Date.new(2021), funder_type: "accelerator" }
-    let!(:funder_2) { create :funder, date_joined_fora: Date.new(2021), funder_type: "accelerator" }
-    let!(:funder_3) { create :funder, date_joined_fora: Date.new(2021), funder_type: "advisory" }
-    let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030), funder_type: "accelerator" }
+    let!(:funder_1) { create :funder, funder_type: "accelerator" }
+    let!(:funder_2) { create :funder, funder_type: "accelerator" }
+    let!(:funder_3) { create :funder, funder_type: "advisory" }
+    let!(:ignored_funder) { create :funder, funder_type: "accelerator" }
+    let!(:ignored_funder_different_privacy) { create :funder, funder_type: "accelerator" }
+    let!(:investment_1) { create :investment, funder: funder_1, year_invested: 2021, privacy: "all" }
+    let!(:investment_2) { create :investment, funder: funder_2, year_invested: 2021, privacy: "all" }
+    let!(:investment_3) { create :investment, funder: funder_3, year_invested: 2021, privacy: "all" }
+    let!(:ignored_investment) { create :investment, funder: ignored_funder, year_invested: 2030, privacy: "all" }
+    let!(:ignored_investment_with_different_privacy) do
+      create :investment, funder: ignored_funder_different_privacy, year_invested: 2021, privacy: "visible_only_to_members"
+    end
 
     it "contains correct header" do
       expect(result[:headers].first[:label]).to eq(I18n.t("activerecord.models.funder_type.one"))

--- a/backend/spec/services/widgets/queries/total_projects_funders_areas_spec.rb
+++ b/backend/spec/services/widgets/queries/total_projects_funders_areas_spec.rb
@@ -5,19 +5,18 @@ RSpec.describe Widgets::Queries::TotalProjectsFundersAreas do
 
   describe "#call" do
     let(:result) { subject.call }
-    let(:funder_1) { create :funder, date_joined_fora: Date.new(2021), areas: ["equity_and_justice"] }
-    let(:funder_2) { create :funder, date_joined_fora: Date.new(2021), areas: ["food_sovereignty"] }
+    let(:funder_1) { create :funder }
     let!(:investment_1) do
       create :investment, year_invested: 2021, privacy: "all", funder: funder_1, areas: ["equity_and_justice"]
     end
     let!(:investment_2) do
-      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_2, areas: ["equity_and_justice", "food_sovereignty"]
+      create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_1, areas: ["equity_and_justice", "food_sovereignty"]
     end
     let!(:ignored_investment_with_different_year) do
-      create :investment, year_invested: 2030, privacy: "all", funder: funder_2, areas: ["equity_and_justice"]
+      create :investment, year_invested: 2030, privacy: "all", areas: ["equity_and_justice"]
     end
     let!(:ignored_investment_with_different_privacy) do
-      create :investment, year_invested: 2021, privacy: "visible_only_to_members", funder: funder_2, areas: ["equity_and_justice"]
+      create :investment, year_invested: 2021, privacy: "visible_only_to_members", areas: ["equity_and_justice"]
     end
 
     it "contains correct header" do

--- a/backend/spec/services/widgets/queries/total_projects_funders_subgeographics_spec.rb
+++ b/backend/spec/services/widgets/queries/total_projects_funders_subgeographics_spec.rb
@@ -34,20 +34,18 @@ RSpec.describe Widgets::Queries::TotalProjectsFundersSubgeographics do
       let!(:region) { create :subgeographic, geographic: :regions, parent: country_1 }
       let!(:country_2) { create :subgeographic, geographic: :countries, name: "CCCC" }
       let!(:ignored_country) { create :subgeographic, geographic: :countries, name: "BBBB" }
-      let!(:funder_1) { create :funder, date_joined_fora: Date.new(2021), subgeographics: [country_1] }
-      let!(:funder_2) { create :funder, date_joined_fora: Date.new(2021), subgeographics: [country_2] }
-      let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030), subgeographics: [country_2] }
+      let!(:funder_1) { create :funder }
       let!(:investment_1) do
         create :investment, year_invested: 2021, privacy: "all", funder: funder_1, subgeographics: [region]
       end
       let!(:investment_2) do
-        create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_2, subgeographics: [country_1, country_2]
+        create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_1, subgeographics: [country_1, country_2]
       end
       let!(:ignored_investment_with_different_year) do
-        create :investment, year_invested: 2030, privacy: "all", funder: funder_1, subgeographics: [region]
+        create :investment, year_invested: 2030, privacy: "all", subgeographics: [region]
       end
       let!(:ignored_investment_with_different_privacy) do
-        create :investment, year_invested: 2021, privacy: "visible_only_to_members", funder: funder_1, subgeographics: [region]
+        create :investment, year_invested: 2021, privacy: "visible_only_to_members", subgeographics: [region]
       end
 
       it "contains correct header" do
@@ -84,20 +82,18 @@ RSpec.describe Widgets::Queries::TotalProjectsFundersSubgeographics do
       let!(:state) { create :subgeographic, geographic: :states, parent: region_1 }
       let!(:region_2) { create :subgeographic, geographic: :regions, name: "CCCC" }
       let!(:region_3) { create :subgeographic, geographic: :regions, name: "BBBB" }
-      let!(:funder_1) { create :funder, date_joined_fora: Date.new(2021), subgeographics: [region_1, state] }
-      let!(:funder_2) { create :funder, date_joined_fora: Date.new(2021), subgeographics: [region_2] }
-      let!(:ignored_funder) { create :funder, date_joined_fora: Date.new(2030), subgeographics: [region_2] }
+      let(:funder_1) { create :funder }
       let!(:investment_1) do
         create :investment, year_invested: 2021, privacy: "all", funder: funder_1, subgeographics: [state]
       end
       let!(:investment_2) do
-        create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_2, subgeographics: [region_1, region_2]
+        create :investment, year_invested: 2021, privacy: "amount_funded_visible_only_to_members", funder: funder_1, subgeographics: [region_1, region_2]
       end
       let!(:ignored_investment_with_different_year) do
-        create :investment, year_invested: 2030, privacy: "all", funder: funder_1, subgeographics: [state]
+        create :investment, year_invested: 2030, privacy: "all", subgeographics: [state]
       end
       let!(:ignored_investment_with_different_privacy) do
-        create :investment, year_invested: 2021, privacy: "visible_only_to_members", funder: funder_1, subgeographics: [state]
+        create :investment, year_invested: 2021, privacy: "visible_only_to_members", subgeographics: [state]
       end
 
       it "contains correct header" do


### PR DESCRIPTION
This PR refactors all widgets related to Funders which used `date_joined_fora` attribute and instead use `year_invested ` attribute from investment table. I have discussed this change with Sofia during QA and it was super confusing that Widgets at dashboard used `year_invested` for Projects and  `date_joined_fora` for Funders so we have decided to refactor this so just one attribute is used and results make more sense to user.

From tech point of view, I just tweaked db queries of 5 widgets and updated tests ;)