### PR TITLE
[FORA-370] adds fallback when there are no areas of focus selected

### DIFF
--- a/client/src/components/forms/tree-select/index.tsx
+++ b/client/src/components/forms/tree-select/index.tsx
@@ -460,6 +460,7 @@ const InnerTreeSelect = <IsMulti extends boolean>(
                 value={searchTerm}
                 placeholder={selected === null ? placeholder : null}
                 theme={theme}
+                className="pl-0"
                 autoFocus={autoFocus}
                 onClick={(e) => {
                   e.stopPropagation();

--- a/client/src/components/forms/tree-select/search-input.tsx
+++ b/client/src/components/forms/tree-select/search-input.tsx
@@ -1,8 +1,8 @@
 import type { InputHTMLAttributes } from 'react';
 
-import classNames from 'classnames';
-
 import { LuX } from 'react-icons/lu';
+
+import { cn } from '@/lib/utils';
 
 import type { CommonTreeProps } from './types';
 
@@ -28,16 +28,16 @@ const SearchInput = ({
         value={value}
         placeholder={placeholder}
         disabled={disabled}
-        className={classNames(
-          'h-[32px] w-full appearance-none truncate border-none bg-transparent p-0 py-2 pl-2 text-sm focus:ring-0',
-          {
-            // 'pl-2': multiple,
-            'placeholder:text-gray-300': disabled,
-            'placeholder:text-grey-0': !disabled,
-          },
-        )}
         autoComplete="off"
         {...inputProps}
+        className={cn(
+          'h-[32px] w-full appearance-none truncate border-none bg-transparent p-0 py-2 pl-2 text-sm focus:ring-0',
+          {
+            'placeholder:text-gray-300': disabled,
+            'placeholder:text-grey-0': !disabled,
+            [inputProps.className]: !!inputProps.className,
+          },
+        )}
       />
       {value && (
         <button type="button" onClick={resetSearch} className="flex-shrink-0">

--- a/client/src/containers/auth/details/form/steps/focus-collaboration/areas.tsx
+++ b/client/src/containers/auth/details/form/steps/focus-collaboration/areas.tsx
@@ -33,7 +33,7 @@ export default function AreasSelector() {
     if (!areas) return;
 
     const selected = areas
-      .filter((area) => areasFormValues.some((selectedValue) => selectedValue === area.id))
+      .filter((area) => areasFormValues?.some((selectedValue) => selectedValue === area.id))
       .map((area) => ({
         label: area.name,
         value: area.id,

--- a/client/src/containers/auth/details/form/steps/focus-collaboration/geographic-scope-states.tsx
+++ b/client/src/containers/auth/details/form/steps/focus-collaboration/geographic-scope-states.tsx
@@ -31,7 +31,7 @@ export default function GeographicScopeStatesSelector() {
   );
 
   const isUSA = countries
-    .filter((country) => countriesFormValues.includes(country.id))
+    ?.filter((country) => countriesFormValues?.includes(country.id))
     .some((country) => country.code === 'USA');
 
   const {


### PR DESCRIPTION
This pull request includes several updates to improve the functionality and maintainability of form components and selectors in the `client` directory. The most important changes involve enhancing class handling, improving null safety, and simplifying imports.

### Improvements to class handling:
* [`client/src/components/forms/tree-select/index.tsx`](diffhunk://#diff-193beb258abb9d9fc21ef1e42a356dbbb09262b23068a0bf0191469534557b06R463): Added a `className` property (`pl-0`) to the search input for better alignment in the `InnerTreeSelect` component.
* [`client/src/components/forms/tree-select/search-input.tsx`](diffhunk://#diff-46fc5d0fbc9da1d198407b9a3826224497485883bbb947879c455f1c1b3f4f62L3-R6): Replaced `classnames` with a custom utility function `cn` for class merging, and updated the `className` logic to include `inputProps.className` dynamically. [[1]](diffhunk://#diff-46fc5d0fbc9da1d198407b9a3826224497485883bbb947879c455f1c1b3f4f62L3-R6) [[2]](diffhunk://#diff-46fc5d0fbc9da1d198407b9a3826224497485883bbb947879c455f1c1b3f4f62L31-L40)

### Improvements to null safety:
* [`client/src/containers/auth/details/form/steps/focus-collaboration/areas.tsx`](diffhunk://#diff-df6e51fe84dc1ce075f66f5817afdce298e0d9172ee5111867d78b1cd76445dfL36-R36): Added optional chaining (`?.`) to safely access `areasFormValues` when filtering selected areas.
* [`client/src/containers/auth/details/form/steps/focus-collaboration/geographic-scope-states.tsx`](diffhunk://#diff-341558eea49ee47872d83505d5fc7eeefdb3f4790f6a09bd4651dd4636c7fcc1L34-R34): Added optional chaining (`?.`) to safely access `countriesFormValues` when filtering selected countries.

### Simplification of imports:
* [`client/src/components/forms/tree-select/search-input.tsx`](diffhunk://#diff-46fc5d0fbc9da1d198407b9a3826224497485883bbb947879c455f1c1b3f4f62L3-R6): Removed the `classnames` library import in favor of the `cn` utility function for consistency and reduced dependency.