### PR TITLE
[Security] Fix dependabot alert #170: pbkdf2 silently disregards Uint8Array input, returning static keys

### DIFF
--- a/.copilot/dependabot-alert-170.md
+++ b/.copilot/dependabot-alert-170.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #170
+
+**Summary:** pbkdf2 silently disregards Uint8Array input, returning static keys
+**Severity:** critical
+**Package:** pbkdf2
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 170,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "npm",
      "name": "pbkdf2"
    },
    "manifest_path": "client/pnpm-lock.yaml",
    "scope": "runtime",
    "relationship": "transitive"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-v62p-rq8g-8h59",
    "cve_id": "CVE-2025-6547",
    "summary": "pbkdf2 silently disregards Uint8Array input, returning static keys",
    "description": "### Summary\n\nOn historic but declared as supported Node.js versions (0.12-2.x), pbkdf2 silently disregards Uint8Array input\n\nThis only affects Node.js <3.0.0, but `pbkdf2` claims to:\n * Support Node.js [>= 0.12](https://github.com/browserify/pbkdf2/blob/v3.1.2/package.json#L62) (and there seems to be ongoing effort in this repo to maintain that)\n * Support `Uint8Array` input (input is typechecked against Uint8Array, and the error message includes e.g. \"Password must be a string, a Buffer, a typed array or a DataView\"\n\n### Details\n\nThe error is in `toBuffer` method\n\nThis vulnerability somehow even made it to tests: https://github.com/browserify/pbkdf2/commit/eb9f97a66ed83836bebc4ff563a1588248708501\nThere, `resultsOld` (where mismatch `results`) are just invalid output generated from empty password/salt instead of the supplied one\n\n### PoC\n\nOn Node.js/io.js < 3.0.0\n\n```console\n> require('pbkdf2').pbkdf2Sync(new Uint8Array([1,2,3]), new Uint8Array([1,3,4]), 1024, 32, 'sha256')\n<Buffer 21 53 cd 5b a5 f0 15 39 2f 68 e2 40 8b 21 ba ca 0e dc 7b 20 d5 45 a4 8a ea b5 95 9f f0 be bf 66>\n\n// But that's just a hash of empty data with empty password:\n> require('pbkdf2').pbkdf2Sync('', '', 1024, 32, 'sha256')\n<Buffer 21 53 cd 5b a5 f0 15 39 2f 68 e2 40 8b 21 ba ca 0e dc 7b 20 d5 45 a4 8a ea b5 95 9f f0 be bf 66>\n\n// Node.js crypto is fine even on that version:\n> require('crypto').pbkdf2Sync(new Uint8Array([1,2,3]), new Uint8Array([1,3,4]), 1024, 32, 'sha256')\n<Buffer 78 10 cc 84 b7 bb 85 cd c8 37 ca 68 da a9 4c 33 db ae c2 3d 5b d4 95 76 da 33 f9 95 ac 51 f4 45>\n\n// Empty hash from Node.js, for comparison\n> require('crypto').pbkdf2Sync('', '', 1024, 32, 'sha256')\n<Buffer 21 53 cd 5b a5 f0 15 39 2f 68 e2 40 8b 21 ba ca 0e dc 7b 20 d5 45 a4 8a ea b5 95 9f f0 be bf 66>\n```\n\n### Impact\n\nStatic hashes being outputted and used as keys/passwords can completely undermine security\nThat said, no one should be using those Node.js versions anywhere now, so I would recommend to just drop them\nThis lib should not pretend to work on those versions while outputting static data though\n\nJust updating to a fixed version is not enough: if anyone was using `pbkdf2` lib (do not confuse with Node.js `crypto.pbkdf2`) or anything depending on it with Node.js/io.js < 3.0.0, recheck where those keys went / how they were used,  and take action accordingly",
    "severity": "critical",
    "identifiers": [
      {
        "value": "GHSA-v62p-rq8g-8h59",
        "type": "GHSA"
      },
      {
        "value": "CVE-2025-6547",
        "type": "CVE"
      }
    ],
    "references": [
      {
        "url": "https://github.com/browserify/pbkdf2/security/advisories/GHSA-v62p-rq8g-8h59"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-6547"
      },
      {
        "url": "https://github.com/browserify/pbkdf2/commit/e3102a8cd4830a3ac85cd0dd011cc002fdde33bb"
      },
      {
        "url": "https://github.com/advisories/GHSA-v62p-rq8g-8h59"
      }
    ],
    "published_at": "2025-06-23T22:42:00Z",
    "updated_at": "2026-02-17T16:39:01Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "npm",
          "name": "pbkdf2"
        },
        "severity": "critical",
        "vulnerable_version_range": ">= 1.0.0, <= 3.1.2",
        "first_patched_version": {
          "identifier": "3.1.3"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": null,
        "score": 0
      },
      "cvss_v4": {
        "vector_string": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:N/VI:H/VA:N/SC:H/SI:H/SA:H",
        "score": 9.1
      }
    },
    "epss": {
      "percentage": 0.00022,
      "percentile": 0.05656
    },
    "cvss": {
      "vector_string": null,
      "score": 0
    },
    "cwes": [
      {
        "cwe_id": "CWE-20",
        "name": "Improper Input Validation"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "npm",
      "name": "pbkdf2"
    },
    "severity": "critical",
    "vulnerable_version_range": ">= 1.0.0, <= 3.1.2",
    "first_patched_version": {
      "identifier": "3.1.3"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/170",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/170",
  "created_at": "2026-02-17T19:25:06Z",
  "updated_at": "2026-02-17T19:25:06Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/browserify/pbkdf2/security/advisories/GHSA-v62p-rq8g-8h59, https://nvd.nist.gov/vuln/detail/CVE-2025-6547, https://github.com/browserify/pbkdf2/commit/e3102a8cd4830a3ac85cd0dd011cc002fdde33bb, https://github.com/advisories/GHSA-v62p-rq8g-8h59