### PR TITLE
[Security] Fix dependabot alert #164: Next.js HTTP request deserialization can lead to DoS when using insecure React Server Components

### DIFF
--- a/.copilot/dependabot-alert-164.md
+++ b/.copilot/dependabot-alert-164.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #164
+
+**Summary:** Next.js HTTP request deserialization can lead to DoS when using insecure React Server Components
+**Severity:** high
+**Package:** next
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 164,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "npm",
      "name": "next"
    },
    "manifest_path": "client/pnpm-lock.yaml",
    "scope": "runtime",
    "relationship": "direct"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-h25m-26qc-wcjf",
    "cve_id": null,
    "summary": "Next.js HTTP request deserialization can lead to DoS when using insecure React Server Components",
    "description": "A vulnerability affects certain React Server Components packages for versions 19.0.x, 19.1.x, and 19.2.x and frameworks that use the affected packages, including Next.js 13.x, 14.x, 15.x, and 16.x using the App Router. The issue is tracked upstream as [CVE-2026-23864](https://github.com/facebook/react/security/advisories/GHSA-83fc-fqcc-2hmg).\n\nA specially crafted HTTP request can be sent to any App Router Server Function endpoint that, when deserialized, may trigger excessive CPU usage, out-of-memory exceptions, or server crashes. This can result in denial of service in unpatched environments.",
    "severity": "high",
    "identifiers": [
      {
        "value": "GHSA-h25m-26qc-wcjf",
        "type": "GHSA"
      }
    ],
    "references": [
      {
        "url": "https://github.com/facebook/react/security/advisories/GHSA-83fc-fqcc-2hmg"
      },
      {
        "url": "https://github.com/vercel/next.js/security/advisories/GHSA-h25m-26qc-wcjf"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23864"
      },
      {
        "url": "https://vercel.com/changelog/summary-of-cve-2026-23864"
      },
      {
        "url": "https://github.com/advisories/GHSA-h25m-26qc-wcjf"
      }
    ],
    "published_at": "2026-01-28T15:38:01Z",
    "updated_at": "2026-01-28T15:38:02Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 13.0.0, < 15.0.8",
        "first_patched_version": {
          "identifier": "15.0.8"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.1.1-canary.0, < 15.1.12",
        "first_patched_version": {
          "identifier": "15.1.12"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.2.0-canary.0, < 15.2.9",
        "first_patched_version": {
          "identifier": "15.2.9"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.3.0-canary.0, < 15.3.9",
        "first_patched_version": {
          "identifier": "15.3.9"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.4.0-canary.0, < 15.4.11",
        "first_patched_version": {
          "identifier": "15.4.11"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.5.1-canary.0, < 15.5.10",
        "first_patched_version": {
          "identifier": "15.5.10"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.6.0-canary.0, < 15.6.0-canary.61",
        "first_patched_version": {
          "identifier": "15.6.0-canary.61"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 16.0.0-beta.0, < 16.0.11",
        "first_patched_version": {
          "identifier": "16.0.11"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 16.1.0-canary.0, < 16.1.5",
        "first_patched_version": {
          "identifier": "16.1.5"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
        "score": 7.5
      },
      "cvss_v4": {
        "vector_string": null,
        "score": 0
      }
    },
    "cvss": {
      "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
      "score": 7.5
    },
    "cwes": [
      {
        "cwe_id": "CWE-400",
        "name": "Uncontrolled Resource Consumption"
      },
      {
        "cwe_id": "CWE-502",
        "name": "Deserialization of Untrusted Data"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "npm",
      "name": "next"
    },
    "severity": "high",
    "vulnerable_version_range": ">= 13.0.0, < 15.0.8",
    "first_patched_version": {
      "identifier": "15.0.8"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/164",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/164",
  "created_at": "2026-01-31T02:24:36Z",
  "updated_at": "2026-01-31T02:24:36Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/facebook/react/security/advisories/GHSA-83fc-fqcc-2hmg, https://github.com/vercel/next.js/security/advisories/GHSA-h25m-26qc-wcjf, https://nvd.nist.gov/vuln/detail/CVE-2026-23864, https://vercel.com/changelog/summary-of-cve-2026-23864, https://github.com/advisories/GHSA-h25m-26qc-wcjf