### PR TITLE
[Security] Fix dependabot alert #152: qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion

### DIFF
--- a/.copilot/dependabot-alert-152.md
+++ b/.copilot/dependabot-alert-152.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #152
+
+**Summary:** qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion
+**Severity:** high
+**Package:** qs
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 152,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "npm",
      "name": "qs"
    },
    "manifest_path": "client/pnpm-lock.yaml",
    "scope": "runtime",
    "relationship": "transitive"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-6rw7-vpxm-498p",
    "cve_id": "CVE-2025-15284",
    "summary": "qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion",
    "description": "### Summary\n\nThe `arrayLimit` option in qs did not enforce limits for bracket notation (`a[]=1&a[]=2`), only for indexed notation (`a[0]=1`). This is a consistency bug; `arrayLimit` should apply uniformly across all array notations.\n\n**Note:** The default `parameterLimit` of 1000 effectively mitigates the DoS scenario originally described. With default options, bracket notation cannot produce arrays larger than `parameterLimit` regardless of `arrayLimit`, because each `a[]=value` consumes one parameter slot. The severity has been reduced accordingly.\n\n### Details\n\nThe `arrayLimit` option only checked limits for indexed notation (`a[0]=1&a[1]=2`) but did not enforce it for bracket notation (`a[]=1&a[]=2`).\n\n**Vulnerable code** (`lib/parse.js:159-162`):\n```javascript\nif (root === '[]' && options.parseArrays) {\n    obj = utils.combine([], leaf);  // No arrayLimit check\n}\n```\n\n**Working code** (`lib/parse.js:175`):\n```javascript\nelse if (index <= options.arrayLimit) {  // Limit checked here\n    obj = [];\n    obj[index] = leaf;\n}\n```\n\nThe bracket notation handler at line 159 uses `utils.combine([], leaf)` without validating against `options.arrayLimit`, while indexed notation at line 175 checks `index <= options.arrayLimit` before creating arrays.\n\n### PoC\n\n```javascript\nconst qs = require('qs');\nconst result = qs.parse('a[]=1&a[]=2&a[]=3&a[]=4&a[]=5&a[]=6', { arrayLimit: 5 });\nconsole.log(result.a.length);  // Output: 6 (should be max 5)\n```\n\n**Note on parameterLimit interaction:** The original advisory's \"DoS demonstration\" claimed a length of 10,000, but `parameterLimit` (default: 1000) caps parsing to 1,000 parameters. With default options, the actual output is 1,000, not 10,000.\n\n### Impact\n\nConsistency bug in `arrayLimit` enforcement. With default `parameterLimit`, the practical DoS risk is negligible since `parameterLimit` already caps the total number of parsed parameters (and thus array elements from bracket notation). The risk increases only when `parameterLimit` is explicitly set to a very high value.",
    "severity": "high",
    "identifiers": [
      {
        "value": "GHSA-6rw7-vpxm-498p",
        "type": "GHSA"
      },
      {
        "value": "CVE-2025-15284",
        "type": "CVE"
      }
    ],
    "references": [
      {
        "url": "https://github.com/ljharb/qs/security/advisories/GHSA-6rw7-vpxm-498p"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-15284"
      },
      {
        "url": "https://github.com/ljharb/qs/commit/3086902ecf7f088d0d1803887643ac6c03d415b9"
      },
      {
        "url": "https://github.com/advisories/GHSA-6rw7-vpxm-498p"
      }
    ],
    "published_at": "2025-12-30T21:02:54Z",
    "updated_at": "2026-02-10T19:59:52Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "npm",
          "name": "qs"
        },
        "severity": "high",
        "vulnerable_version_range": "< 6.14.1",
        "first_patched_version": {
          "identifier": "6.14.1"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
        "score": 7.5
      },
      "cvss_v4": {
        "vector_string": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
        "score": 8.7
      }
    },
    "epss": {
      "percentage": 0.00085,
      "percentile": 0.24606
    },
    "cvss": {
      "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
      "score": 7.5
    },
    "cwes": [
      {
        "cwe_id": "CWE-20",
        "name": "Improper Input Validation"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "npm",
      "name": "qs"
    },
    "severity": "high",
    "vulnerable_version_range": "< 6.14.1",
    "first_patched_version": {
      "identifier": "6.14.1"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/152",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/152",
  "created_at": "2026-01-01T19:27:48Z",
  "updated_at": "2026-01-01T19:27:48Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/ljharb/qs/security/advisories/GHSA-6rw7-vpxm-498p, https://nvd.nist.gov/vuln/detail/CVE-2025-15284, https://github.com/ljharb/qs/commit/3086902ecf7f088d0d1803887643ac6c03d415b9, https://github.com/advisories/GHSA-6rw7-vpxm-498p