### PR TITLE
[Security] Fix dependabot alert #147: Next Vulnerable to Denial of Service with Server Components

### DIFF
--- a/.copilot/dependabot-alert-147.md
+++ b/.copilot/dependabot-alert-147.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #147
+
+**Summary:** Next Vulnerable to Denial of Service with Server Components
+**Severity:** high
+**Package:** next
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 147,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "npm",
      "name": "next"
    },
    "manifest_path": "client/package.json",
    "scope": "runtime",
    "relationship": "direct"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-mwv6-3258-q52c",
    "cve_id": null,
    "summary": "Next Vulnerable to Denial of Service with Server Components",
    "description": "A vulnerability affects certain React packages for versions 19.0.0, 19.0.1, 19.1.0, 19.1.1, 19.1.2, 19.2.0, and 19.2.1 and frameworks that use the affected packages, including Next.js 15.x and 16.x using the App Router. The issue is tracked upstream as [CVE-2025-55184](https://www.cve.org/CVERecord?id=CVE-2025-55184).\n\nA malicious HTTP request can be crafted and sent to any App Router endpoint that, when deserialized, can cause the server process to hang and consume CPU. This can result in denial of service in unpatched environments.",
    "severity": "high",
    "identifiers": [
      {
        "value": "GHSA-mwv6-3258-q52c",
        "type": "GHSA"
      }
    ],
    "references": [
      {
        "url": "https://github.com/vercel/next.js/security/advisories/GHSA-mwv6-3258-q52c"
      },
      {
        "url": "https://nextjs.org/blog/security-update-2025-12-11"
      },
      {
        "url": "https://www.cve.org/CVERecord?id=CVE-2025-55184"
      },
      {
        "url": "https://github.com/advisories/GHSA-mwv6-3258-q52c"
      }
    ],
    "published_at": "2025-12-11T22:49:27Z",
    "updated_at": "2025-12-11T22:49:30Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 13.3.0, < 14.2.34",
        "first_patched_version": {
          "identifier": "14.2.34"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.0.0-canary.0, < 15.0.6",
        "first_patched_version": {
          "identifier": "15.0.6"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.1.1-canary.0, < 15.1.10",
        "first_patched_version": {
          "identifier": "15.1.10"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.2.0-canary.0, < 15.2.7",
        "first_patched_version": {
          "identifier": "15.2.7"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.3.0-canary.0, < 15.3.7",
        "first_patched_version": {
          "identifier": "15.3.7"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.4.0-canary.0, < 15.4.9",
        "first_patched_version": {
          "identifier": "15.4.9"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.5.1-canary.0, < 15.5.8",
        "first_patched_version": {
          "identifier": "15.5.8"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 15.6.0-canary.0, < 15.6.0-canary.59",
        "first_patched_version": {
          "identifier": "15.6.0-canary.59"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 16.0.0-beta.0, < 16.0.9",
        "first_patched_version": {
          "identifier": "16.0.9"
        }
      },
      {
        "package": {
          "ecosystem": "npm",
          "name": "next"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 16.1.0-canary.0, < 16.1.0-canary.17",
        "first_patched_version": {
          "identifier": "16.1.0-canary.17"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
        "score": 7.5
      },
      "cvss_v4": {
        "vector_string": null,
        "score": 0
      }
    },
    "cvss": {
      "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
      "score": 7.5
    },
    "cwes": [
      {
        "cwe_id": "CWE-400",
        "name": "Uncontrolled Resource Consumption"
      },
      {
        "cwe_id": "CWE-502",
        "name": "Deserialization of Untrusted Data"
      },
      {
        "cwe_id": "CWE-1395",
        "name": "Dependency on Vulnerable Third-Party Component"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "npm",
      "name": "next"
    },
    "severity": "high",
    "vulnerable_version_range": ">= 13.3.0, < 14.2.34",
    "first_patched_version": {
      "identifier": "14.2.34"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/147",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/147",
  "created_at": "2025-12-13T13:47:52Z",
  "updated_at": "2025-12-13T13:47:52Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/vercel/next.js/security/advisories/GHSA-mwv6-3258-q52c, https://nextjs.org/blog/security-update-2025-12-11, https://www.cve.org/CVERecord?id=CVE-2025-55184, https://github.com/advisories/GHSA-mwv6-3258-q52c