### PR TITLE
[Security] Fix dependabot alert #136: Rack is vulnerable to a memory-exhaustion DoS through unbounded URL-encoded body parsing

### DIFF
--- a/.copilot/dependabot-alert-136.md
+++ b/.copilot/dependabot-alert-136.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #136
+
+**Summary:** Rack is vulnerable to a memory-exhaustion DoS through unbounded URL-encoded body parsing
+**Severity:** high
+**Package:** rack
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 136,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "manifest_path": "client/Gemfile.lock",
    "scope": "runtime",
    "relationship": "unknown"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-6xw4-3v39-52mm",
    "cve_id": "CVE-2025-61919",
    "summary": "Rack is vulnerable to a memory-exhaustion DoS through unbounded URL-encoded body parsing",
    "description": "## Summary\n\n`Rack::Request#POST` reads the entire request body into memory for `Content-Type: application/x-www-form-urlencoded`, calling `rack.input.read(nil)` without enforcing a length or cap. Large request bodies can therefore be buffered completely into process memory before parsing, leading to denial of service (DoS) through memory exhaustion.\n\n## Details\n\nWhen handling non-multipart form submissions, Rack’s request parser performs:\n\n```ruby\nform_vars = get_header(RACK_INPUT).read\n```\n\nSince `read` is called with no argument, the entire request body is loaded into a Ruby `String`. This occurs before query parameter parsing or enforcement of any `params_limit`. As a result, Rack applications without an upstream body-size limit can experience unbounded memory allocation proportional to request size.\n\n## Impact\n\nAttackers can send large `application/x-www-form-urlencoded` bodies to consume process memory, causing slowdowns or termination by the operating system (OOM). The effect scales linearly with request size and concurrency. Even with parsing limits configured, the issue occurs *before* those limits are enforced.\n\n## Mitigation\n\n* Update to a patched version of Rack that enforces form parameter limits using `query_parser.bytesize_limit`, preventing unbounded reads of `application/x-www-form-urlencoded` bodies.\n* Enforce strict maximum body size at the proxy or web server layer (e.g., Nginx `client_max_body_size`, Apache `LimitRequestBody`).",
    "severity": "high",
    "identifiers": [
      {
        "value": "GHSA-6xw4-3v39-52mm",
        "type": "GHSA"
      },
      {
        "value": "CVE-2025-61919",
        "type": "CVE"
      }
    ],
    "references": [
      {
        "url": "https://github.com/rack/rack/security/advisories/GHSA-6xw4-3v39-52mm"
      },
      {
        "url": "https://github.com/rack/rack/commit/4e2c903991a790ee211a3021808ff4fd6fe82881"
      },
      {
        "url": "https://github.com/rack/rack/commit/cbd541e8a3d0c5830a3c9a30d3718ce2e124f9db"
      },
      {
        "url": "https://github.com/rack/rack/commit/e179614c4a653283286f5f046428cbb85f21146f"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61919"
      },
      {
        "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2025-61919.yml"
      },
      {
        "url": "https://github.com/advisories/GHSA-6xw4-3v39-52mm"
      }
    ],
    "published_at": "2025-10-10T17:33:35Z",
    "updated_at": "2025-10-13T15:46:18Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": "< 2.2.20",
        "first_patched_version": {
          "identifier": "2.2.20"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 3.0, < 3.1.18",
        "first_patched_version": {
          "identifier": "3.1.18"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 3.2, < 3.2.3",
        "first_patched_version": {
          "identifier": "3.2.3"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
        "score": 7.5
      },
      "cvss_v4": {
        "vector_string": null,
        "score": 0
      }
    },
    "epss": {
      "percentage": 0.00232,
      "percentile": 0.45705
    },
    "cvss": {
      "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
      "score": 7.5
    },
    "cwes": [
      {
        "cwe_id": "CWE-400",
        "name": "Uncontrolled Resource Consumption"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "severity": "high",
    "vulnerable_version_range": "< 2.2.20",
    "first_patched_version": {
      "identifier": "2.2.20"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/136",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/136",
  "created_at": "2025-10-10T18:16:20Z",
  "updated_at": "2025-10-10T18:16:20Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/rack/rack/security/advisories/GHSA-6xw4-3v39-52mm, https://github.com/rack/rack/commit/4e2c903991a790ee211a3021808ff4fd6fe82881, https://github.com/rack/rack/commit/cbd541e8a3d0c5830a3c9a30d3718ce2e124f9db, https://github.com/rack/rack/commit/e179614c4a653283286f5f046428cbb85f21146f, https://nvd.nist.gov/vuln/detail/CVE-2025-61919, https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2025-61919.yml, https://github.com/advisories/GHSA-6xw4-3v39-52mm