### PR TITLE
[Security] Fix dependabot alert #132: Rack: Multipart parser buffers large non‑file fields entirely in memory, enabling DoS (memory exhaustion)

### DIFF
--- a/.copilot/dependabot-alert-132.md
+++ b/.copilot/dependabot-alert-132.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #132
+
+**Summary:** Rack: Multipart parser buffers large non‑file fields entirely in memory, enabling DoS (memory exhaustion)
+**Severity:** high
+**Package:** rack
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 132,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "manifest_path": "client/Gemfile.lock",
    "scope": "runtime",
    "relationship": "unknown"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-w9pc-fmgc-vxvw",
    "cve_id": "CVE-2025-61771",
    "summary": "Rack: Multipart parser buffers large non‑file fields entirely in memory, enabling DoS (memory exhaustion)",
    "description": "## Summary\n\n`Rack::Multipart::Parser` stores non-file form fields (parts without a `filename`) entirely in memory as Ruby `String` objects. A single large text field in a multipart/form-data request (hundreds of megabytes or more) can consume equivalent process memory, potentially leading to out-of-memory (OOM) conditions and denial of service (DoS).\n\n## Details\n\nDuring multipart parsing, file parts are streamed to temporary files, but non-file parts are buffered into memory:\n\n```ruby\nbody = String.new  # non-file → in-RAM buffer\n@mime_parts[mime_index].body << content\n```\n\nThere is no size limit on these in-memory buffers. As a result, any large text field—while technically valid—will be loaded fully into process memory before being added to `params`.\n\n## Impact\n\nAttackers can send large non-file fields to trigger excessive memory usage. Impact scales with request size and concurrency, potentially leading to worker crashes or severe garbage-collection overhead. All Rack applications processing multipart form submissions are affected.\n\n## Mitigation\n\n* **Upgrade:** Use a patched version of Rack that enforces a reasonable size cap for non-file fields (e.g., 2 MiB).\n* **Workarounds:**\n  * Restrict maximum request body size at the web-server or proxy layer (e.g., Nginx `client_max_body_size`).\n  * Validate and reject unusually large form fields at the application level.",
    "severity": "high",
    "identifiers": [
      {
        "value": "GHSA-w9pc-fmgc-vxvw",
        "type": "GHSA"
      },
      {
        "value": "CVE-2025-61771",
        "type": "CVE"
      }
    ],
    "references": [
      {
        "url": "https://github.com/rack/rack/security/advisories/GHSA-w9pc-fmgc-vxvw"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61771"
      },
      {
        "url": "https://github.com/rack/rack/commit/589127f4ac8b5cf11cf88fb0cd116ffed4d2181e"
      },
      {
        "url": "https://github.com/rack/rack/commit/d869fed663b113b95a74ad53e1b5cae6ab31f29e"
      },
      {
        "url": "https://github.com/rack/rack/commit/e08f78c656c9394d6737c022bde087e0f33336fd"
      },
      {
        "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2025-61771.yml"
      },
      {
        "url": "https://github.com/advisories/GHSA-w9pc-fmgc-vxvw"
      }
    ],
    "published_at": "2025-10-07T17:27:07Z",
    "updated_at": "2025-10-13T15:29:52Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": "< 2.2.19",
        "first_patched_version": {
          "identifier": "2.2.19"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 3.1, < 3.1.17",
        "first_patched_version": {
          "identifier": "3.1.17"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 3.2, < 3.2.2",
        "first_patched_version": {
          "identifier": "3.2.2"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
        "score": 7.5
      },
      "cvss_v4": {
        "vector_string": null,
        "score": 0
      }
    },
    "epss": {
      "percentage": 0.00133,
      "percentile": 0.33237
    },
    "cvss": {
      "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
      "score": 7.5
    },
    "cwes": [
      {
        "cwe_id": "CWE-400",
        "name": "Uncontrolled Resource Consumption"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "severity": "high",
    "vulnerable_version_range": "< 2.2.19",
    "first_patched_version": {
      "identifier": "2.2.19"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/132",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/132",
  "created_at": "2025-10-07T18:43:18Z",
  "updated_at": "2025-10-07T18:43:18Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/rack/rack/security/advisories/GHSA-w9pc-fmgc-vxvw, https://nvd.nist.gov/vuln/detail/CVE-2025-61771, https://github.com/rack/rack/commit/589127f4ac8b5cf11cf88fb0cd116ffed4d2181e, https://github.com/rack/rack/commit/d869fed663b113b95a74ad53e1b5cae6ab31f29e, https://github.com/rack/rack/commit/e08f78c656c9394d6737c022bde087e0f33336fd, https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2025-61771.yml, https://github.com/advisories/GHSA-w9pc-fmgc-vxvw