### PR TITLE
[Security] Fix dependabot alert #130: Rack's unbounded multipart preamble buffering enables DoS (memory exhaustion)

### DIFF
--- a/.copilot/dependabot-alert-130.md
+++ b/.copilot/dependabot-alert-130.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #130
+
+**Summary:** Rack's unbounded multipart preamble buffering enables DoS (memory exhaustion)
+**Severity:** high
+**Package:** rack
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 130,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "manifest_path": "client/Gemfile.lock",
    "scope": "runtime",
    "relationship": "unknown"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-p543-xpfm-54cp",
    "cve_id": "CVE-2025-61770",
    "summary": "Rack's unbounded multipart preamble buffering enables DoS (memory exhaustion)",
    "description": "## Summary\n\n`Rack::Multipart::Parser` buffers the entire multipart **preamble** (bytes before the first boundary) in memory without any size limit. A client can send a large preamble followed by a valid boundary, causing significant memory use and potential process termination due to out-of-memory (OOM) conditions.\n\n## Details\n\nWhile searching for the first boundary, the parser appends incoming data into a shared buffer (`@sbuf.concat(content)`) and scans for the boundary pattern:\n\n```ruby\n@sbuf.scan_until(@body_regex)\n```\n\nIf the boundary is not yet found, the parser continues buffering data indefinitely. There is no trimming or size cap on the preamble, allowing attackers to send arbitrary amounts of data before the first boundary.\n\n## Impact\n\nRemote attackers can trigger large transient memory spikes by including a long preamble in multipart/form-data requests. The impact scales with allowed request sizes and concurrency, potentially causing worker crashes or severe slowdown due to garbage collection.\n\n## Mitigation\n\n* **Upgrade:** Use a patched version of Rack that enforces a preamble size limit (e.g., 16 KiB) or discards preamble data entirely per [RFC 2046 § 5.1.1](https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1).\n* **Workarounds:**\n  * Limit total request body size at the proxy or web server level.\n  * Monitor memory and set per-process limits to prevent OOM conditions.",
    "severity": "high",
    "identifiers": [
      {
        "value": "GHSA-p543-xpfm-54cp",
        "type": "GHSA"
      },
      {
        "value": "CVE-2025-61770",
        "type": "CVE"
      }
    ],
    "references": [
      {
        "url": "https://github.com/rack/rack/security/advisories/GHSA-p543-xpfm-54cp"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61770"
      },
      {
        "url": "https://github.com/rack/rack/commit/589127f4ac8b5cf11cf88fb0cd116ffed4d2181e"
      },
      {
        "url": "https://github.com/rack/rack/commit/d869fed663b113b95a74ad53e1b5cae6ab31f29e"
      },
      {
        "url": "https://github.com/rack/rack/commit/e08f78c656c9394d6737c022bde087e0f33336fd"
      },
      {
        "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2025-61770.yml"
      },
      {
        "url": "https://github.com/advisories/GHSA-p543-xpfm-54cp"
      }
    ],
    "published_at": "2025-10-07T17:26:16Z",
    "updated_at": "2025-10-13T15:29:38Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": "< 2.2.19",
        "first_patched_version": {
          "identifier": "2.2.19"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 3.1, < 3.1.17",
        "first_patched_version": {
          "identifier": "3.1.17"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 3.2, < 3.2.2",
        "first_patched_version": {
          "identifier": "3.2.2"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
        "score": 7.5
      },
      "cvss_v4": {
        "vector_string": null,
        "score": 0
      }
    },
    "epss": {
      "percentage": 0.00215,
      "percentile": 0.43864
    },
    "cvss": {
      "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
      "score": 7.5
    },
    "cwes": [
      {
        "cwe_id": "CWE-400",
        "name": "Uncontrolled Resource Consumption"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "severity": "high",
    "vulnerable_version_range": "< 2.2.19",
    "first_patched_version": {
      "identifier": "2.2.19"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/130",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/130",
  "created_at": "2025-10-07T18:43:15Z",
  "updated_at": "2025-10-07T18:43:15Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/rack/rack/security/advisories/GHSA-p543-xpfm-54cp, https://nvd.nist.gov/vuln/detail/CVE-2025-61770, https://github.com/rack/rack/commit/589127f4ac8b5cf11cf88fb0cd116ffed4d2181e, https://github.com/rack/rack/commit/d869fed663b113b95a74ad53e1b5cae6ab31f29e, https://github.com/rack/rack/commit/e08f78c656c9394d6737c022bde087e0f33336fd, https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2025-61770.yml, https://github.com/advisories/GHSA-p543-xpfm-54cp