### PR TITLE
[Security] Fix dependabot alert #129: Rack's multipart parser buffers unbounded per-part headers, enabling DoS (memory exhaustion)

### DIFF
--- a/.copilot/dependabot-alert-129.md
+++ b/.copilot/dependabot-alert-129.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #129
+
+**Summary:** Rack's multipart parser buffers unbounded per-part headers, enabling DoS (memory exhaustion)
+**Severity:** high
+**Package:** rack
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 129,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "manifest_path": "backend/Gemfile.lock",
    "scope": "runtime",
    "relationship": "unknown"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-wpv5-97wm-hp9c",
    "cve_id": "CVE-2025-61772",
    "summary": "Rack's multipart parser buffers unbounded per-part headers, enabling DoS (memory exhaustion)",
    "description": "## Summary\n\n`Rack::Multipart::Parser` can accumulate unbounded data when a multipart part’s header block never terminates with the required blank line (`CRLFCRLF`). The parser keeps appending incoming bytes to memory without a size cap, allowing a remote attacker to exhaust memory and cause a denial of service (DoS).\n\n## Details\n\nWhile reading multipart headers, the parser waits for `CRLFCRLF` using:\n\n```ruby\n@sbuf.scan_until(/(.*?\\r\\n)\\r\\n/m)\n```\n\nIf the terminator never appears, it continues appending data (`@sbuf.concat(content)`) indefinitely. There is no limit on accumulated header bytes, so a single malformed part can consume memory proportional to the request body size.\n\n## Impact\n\nAttackers can send incomplete multipart headers to trigger high memory use, leading to process termination (OOM) or severe slowdown. The effect scales with request size limits and concurrency. All applications handling multipart uploads may be affected.\n\n## Mitigation\n\n* Upgrade to a patched Rack version that caps per-part header size (e.g., 64 KiB).\n* Until then, restrict maximum request sizes at the proxy or web server layer (e.g., Nginx `client_max_body_size`).",
    "severity": "high",
    "identifiers": [
      {
        "value": "GHSA-wpv5-97wm-hp9c",
        "type": "GHSA"
      },
      {
        "value": "CVE-2025-61772",
        "type": "CVE"
      }
    ],
    "references": [
      {
        "url": "https://github.com/rack/rack/security/advisories/GHSA-wpv5-97wm-hp9c"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61772"
      },
      {
        "url": "https://github.com/rack/rack/commit/589127f4ac8b5cf11cf88fb0cd116ffed4d2181e"
      },
      {
        "url": "https://github.com/rack/rack/commit/d869fed663b113b95a74ad53e1b5cae6ab31f29e"
      },
      {
        "url": "https://github.com/rack/rack/commit/e08f78c656c9394d6737c022bde087e0f33336fd"
      },
      {
        "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2025-61772.yml"
      },
      {
        "url": "https://github.com/advisories/GHSA-wpv5-97wm-hp9c"
      }
    ],
    "published_at": "2025-10-07T17:28:06Z",
    "updated_at": "2025-10-13T15:30:02Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": "< 2.2.19",
        "first_patched_version": {
          "identifier": "2.2.19"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 3.1, < 3.1.17",
        "first_patched_version": {
          "identifier": "3.1.17"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": ">= 3.2, < 3.2.2",
        "first_patched_version": {
          "identifier": "3.2.2"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
        "score": 7.5
      },
      "cvss_v4": {
        "vector_string": null,
        "score": 0
      }
    },
    "epss": {
      "percentage": 0.00262,
      "percentile": 0.49226
    },
    "cvss": {
      "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
      "score": 7.5
    },
    "cwes": [
      {
        "cwe_id": "CWE-400",
        "name": "Uncontrolled Resource Consumption"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "severity": "high",
    "vulnerable_version_range": "< 2.2.19",
    "first_patched_version": {
      "identifier": "2.2.19"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/129",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/129",
  "created_at": "2025-10-07T18:42:52Z",
  "updated_at": "2025-10-07T18:42:52Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/rack/rack/security/advisories/GHSA-wpv5-97wm-hp9c, https://nvd.nist.gov/vuln/detail/CVE-2025-61772, https://github.com/rack/rack/commit/589127f4ac8b5cf11cf88fb0cd116ffed4d2181e, https://github.com/rack/rack/commit/d869fed663b113b95a74ad53e1b5cae6ab31f29e, https://github.com/rack/rack/commit/e08f78c656c9394d6737c022bde087e0f33336fd, https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2025-61772.yml, https://github.com/advisories/GHSA-wpv5-97wm-hp9c