### PR TITLE
[Security] Fix dependabot alert #123: Rack has an unsafe default in Rack::QueryParser allows params_limit bypass via semicolon-separated parameters

### DIFF
--- a/.copilot/dependabot-alert-123.md
+++ b/.copilot/dependabot-alert-123.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #123
+
+**Summary:** Rack has an unsafe default in Rack::QueryParser allows params_limit bypass via semicolon-separated parameters
+**Severity:** high
+**Package:** rack
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 123,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "manifest_path": "backend/Gemfile.lock",
    "scope": "runtime",
    "relationship": "unknown"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-625h-95r8-8xpm",
    "cve_id": "CVE-2025-59830",
    "summary": "Rack has an unsafe default in Rack::QueryParser allows params_limit bypass via semicolon-separated parameters",
    "description": "## Summary\n\n`Rack::QueryParser` in version `< 2.2.18` enforces its `params_limit` only for parameters separated by `&`, while still splitting on both `&` and `;`. As a result, attackers could use `;` separators to bypass the parameter count limit and submit more parameters than intended.\n\n## Details\n\nThe issue arises because `Rack::QueryParser#check_query_string` counts only `&` characters when determining the number of parameters, but the default separator regex `DEFAULT_SEP = /[&;] */n` splits on both `&` and `;`. This mismatch means that queries using `;` separators were not included in the parameter count, allowing `params_limit` to be bypassed.\n\nOther safeguards (`bytesize_limit` and `key_space_limit`) still applied, but did not prevent this particular bypass.\n\n## Impact\n\nApplications or middleware that directly invoke `Rack::QueryParser` with its default configuration (no explicit delimiter) could be exposed to increased CPU and memory consumption. This can be abused as a limited denial-of-service vector.\n\n`Rack::Request`, the primary entry point for typical Rack applications, uses `QueryParser` in a safe way and does not appear vulnerable by default. As such, the severity is considered **low**, with the impact limited to edge cases where `QueryParser` is used directly.\n\n## Mitigation\n\n* Upgrade to a patched version of Rack where both `&` and `;` are counted consistently toward `params_limit`.\n* If upgrading is not immediately possible, configure `QueryParser` with an explicit delimiter (e.g., `&`) to avoid the mismatch.\n* As a general precaution, enforce query string and request size limits at the web server or proxy layer (e.g., Nginx, Apache, or a CDN) to mitigate excessive parsing overhead.",
    "severity": "high",
    "identifiers": [
      {
        "value": "GHSA-625h-95r8-8xpm",
        "type": "GHSA"
      },
      {
        "value": "CVE-2025-59830",
        "type": "CVE"
      }
    ],
    "references": [
      {
        "url": "https://github.com/rack/rack/security/advisories/GHSA-625h-95r8-8xpm"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-59830"
      },
      {
        "url": "https://github.com/rack/rack/commit/54e4ffdd5affebcb0c015cc6ae74635c0831ed71"
      },
      {
        "url": "https://github.com/advisories/GHSA-625h-95r8-8xpm"
      }
    ],
    "published_at": "2025-09-25T16:39:27Z",
    "updated_at": "2025-09-25T16:39:27Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "rack"
        },
        "severity": "high",
        "vulnerable_version_range": "< 2.2.18",
        "first_patched_version": {
          "identifier": "2.2.18"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
        "score": 7.5
      },
      "cvss_v4": {
        "vector_string": null,
        "score": 0
      }
    },
    "epss": {
      "percentage": 0.00058,
      "percentile": 0.18219
    },
    "cvss": {
      "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
      "score": 7.5
    },
    "cwes": [
      {
        "cwe_id": "CWE-400",
        "name": "Uncontrolled Resource Consumption"
      },
      {
        "cwe_id": "CWE-770",
        "name": "Allocation of Resources Without Limits or Throttling"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "rubygems",
      "name": "rack"
    },
    "severity": "high",
    "vulnerable_version_range": "< 2.2.18",
    "first_patched_version": {
      "identifier": "2.2.18"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/123",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/123",
  "created_at": "2025-09-25T17:22:32Z",
  "updated_at": "2025-09-25T17:22:32Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/rack/rack/security/advisories/GHSA-625h-95r8-8xpm, https://nvd.nist.gov/vuln/detail/CVE-2025-59830, https://github.com/rack/rack/commit/54e4ffdd5affebcb0c015cc6ae74635c0831ed71, https://github.com/advisories/GHSA-625h-95r8-8xpm