### PR TITLE
[Security] Fix dependabot alert #104: Active Storage allowed transformation methods that were potentially unsafe

### DIFF
--- a/.copilot/dependabot-alert-104.md
+++ b/.copilot/dependabot-alert-104.md
@@ -1,0 +1,7 @@
+# Dependabot Alert #104
+
+**Summary:** Active Storage allowed transformation methods that were potentially unsafe
+**Severity:** critical
+**Package:** activestorage
+
+This file was created to trigger a Copilot fix. It can be removed after the vulnerability is resolved.


### PR DESCRIPTION
## Dependabot Security Alert

```json
{
  "number": 104,
  "state": "open",
  "dependency": {
    "package": {
      "ecosystem": "rubygems",
      "name": "activestorage"
    },
    "manifest_path": "backend/Gemfile.lock",
    "scope": "runtime",
    "relationship": "unknown"
  },
  "security_advisory": {
    "ghsa_id": "GHSA-r4mg-4433-c7g3",
    "cve_id": "CVE-2025-24293",
    "summary": "Active Storage allowed transformation methods that were potentially unsafe",
    "description": "Active Storage attempts to prevent the use of potentially unsafe image transformation methods and parameters by default.\n\nThe default allowed list contains three methods allowing for the circumvention of the safe defaults which enables potential command injection vulnerabilities in cases where arbitrary user supplied input is accepted as valid transformation methods or parameters.\n\nThis has been assigned the CVE identifier CVE-2025-24293.\n\n\nVersions Affected:  >= 5.2.0\nNot affected:       < 5.2.0\nFixed Versions:     7.1.5.2, 7.2.2.2, 8.0.2.1\n\nImpact\n------\nThis vulnerability impacts applications that use Active Storage with the image_processing processing gem in addition to mini_magick as the image processor.\n\nVulnerable code will look something similar to this:\n\n```\n<%= image_tag blob.variant(params[:t] => params[:v]) %>\n```\n\nWhere the transformation method or its arguments are untrusted arbitrary input.\n\nAll users running an affected release should either upgrade or use one of the workarounds immediately.\n\nReleases\n--------\nThe fixed releases are available at the normal locations.\n\nWorkarounds\n-----------\nConsuming user supplied input for image transformation methods or their parameters is unsupported behavior and should be considered dangerous.\n\nStrict validation of user supplied methods and parameters should be performed as well as having a strong [ImageMagick security policy](https://imagemagick.org/script/security-policy.php) deployed.\n\nCredits\n-------\n\nThank you [lio346](https://hackerone.com/lio346) from Unit 515 of OPSWAT for reporting this!",
    "severity": "critical",
    "identifiers": [
      {
        "value": "GHSA-r4mg-4433-c7g3",
        "type": "GHSA"
      },
      {
        "value": "CVE-2025-24293",
        "type": "CVE"
      }
    ],
    "references": [
      {
        "url": "https://github.com/rails/rails/security/advisories/GHSA-r4mg-4433-c7g3"
      },
      {
        "url": "https://github.com/rails/rails/commit/1b1adf6ee6ca0f3104fcfce79360b2ec1e06a354"
      },
      {
        "url": "https://github.com/rails/rails/commit/2d612735ac0d9712fdfffaf80afa627e7295f6ce"
      },
      {
        "url": "https://github.com/rails/rails/commit/fb8f3a18c3d97524c0efc29150d1e5f3162fbb13"
      },
      {
        "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activestorage/CVE-2025-24293.yml"
      },
      {
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-24293"
      },
      {
        "url": "https://github.com/advisories/GHSA-r4mg-4433-c7g3"
      }
    ],
    "published_at": "2025-08-14T00:06:00Z",
    "updated_at": "2026-01-31T03:54:44Z",
    "withdrawn_at": null,
    "vulnerabilities": [
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "activestorage"
        },
        "severity": "critical",
        "vulnerable_version_range": ">= 8.0, < 8.0.2.1",
        "first_patched_version": {
          "identifier": "8.0.2.1"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "activestorage"
        },
        "severity": "critical",
        "vulnerable_version_range": ">= 7.2, < 7.2.2.2",
        "first_patched_version": {
          "identifier": "7.2.2.2"
        }
      },
      {
        "package": {
          "ecosystem": "rubygems",
          "name": "activestorage"
        },
        "severity": "critical",
        "vulnerable_version_range": ">= 5.2.0, < 7.1.5.2",
        "first_patched_version": {
          "identifier": "7.1.5.2"
        }
      }
    ],
    "cvss_severities": {
      "cvss_v3": {
        "vector_string": null,
        "score": 0
      },
      "cvss_v4": {
        "vector_string": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
        "score": 9.2
      }
    },
    "epss": {
      "percentage": 0.00168,
      "percentile": 0.38033
    },
    "cvss": {
      "vector_string": null,
      "score": 0
    },
    "cwes": [
      {
        "cwe_id": "CWE-77",
        "name": "Improper Neutralization of Special Elements used in a Command ('Command Injection')"
      }
    ]
  },
  "security_vulnerability": {
    "package": {
      "ecosystem": "rubygems",
      "name": "activestorage"
    },
    "severity": "critical",
    "vulnerable_version_range": ">= 5.2.0, < 7.1.5.2",
    "first_patched_version": {
      "identifier": "7.1.5.2"
    }
  },
  "url": "https://api.github.com/repos/Vizzuality/fora/dependabot/alerts/104",
  "html_url": "https://github.com/Vizzuality/fora/security/dependabot/104",
  "created_at": "2025-08-14T21:09:38Z",
  "updated_at": "2025-08-14T21:09:38Z",
  "dismissal_request": null,
  "dismissed_at": null,
  "dismissed_by": null,
  "dismissed_reason": null,
  "dismissed_comment": null,
  "fixed_at": null,
  "auto_dismissed_at": null
}
```

## Task

Analyze the alert above and fix the vulnerability.
- Update the affected dependency to the patched version if available.
- If no patch exists, evaluate mitigations or alternatives.
- Run the existing tests to confirm nothing breaks.
- Advisory references: https://github.com/rails/rails/security/advisories/GHSA-r4mg-4433-c7g3, https://github.com/rails/rails/commit/1b1adf6ee6ca0f3104fcfce79360b2ec1e06a354, https://github.com/rails/rails/commit/2d612735ac0d9712fdfffaf80afa627e7295f6ce, https://github.com/rails/rails/commit/fb8f3a18c3d97524c0efc29150d1e5f3162fbb13, https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activestorage/CVE-2025-24293.yml, https://nvd.nist.gov/vuln/detail/CVE-2025-24293, https://github.com/advisories/GHSA-r4mg-4433-c7g3